### PR TITLE
Adds more status code responses

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -52,6 +52,7 @@ library
   build-depends:
       base >=4.7 && <5
     , bytestring
+    , case-insensitive
     , containers
     , http-types
     , json-fleece-aeson
@@ -79,6 +80,7 @@ test-suite orb-test
   build-depends:
       base >=4.7 && <5
     , bytestring
+    , case-insensitive
     , containers
     , http-types
     , json-fleece-aeson

--- a/orb.cabal
+++ b/orb.cabal
@@ -33,12 +33,14 @@ library
   other-modules:
       Orb.Handler
       Orb.Handler.Dispatchable
+      Orb.Handler.Form
       Orb.Handler.Handler
       Orb.Handler.PermissionAction
       Orb.Handler.PermissionError
       Orb.HasRequest
       Orb.HasRespond
       Orb.Response
+      Orb.Response.ContentType
       Orb.Response.Document
       Orb.Response.HasResponse
       Orb.Response.Response
@@ -61,6 +63,7 @@ library
     , text
     , unliftio
     , wai
+    , wai-extra
   default-language: Haskell2010
   if flag(ci)
     ghc-options: -O2 -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wnoncanonical-monad-instances -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe -fwrite-ide-info -hiedir=.hie
@@ -89,4 +92,5 @@ test-suite orb-test
     , text
     , unliftio
     , wai
+    , wai-extra
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -41,6 +41,7 @@ dependencies:
   - text
   - unliftio
   - wai
+  - wai-extra
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ flags:
 dependencies:
   - base >= 4.7 && < 5
   - bytestring
+  - case-insensitive
   - containers
   - http-types
   - json-fleece-aeson

--- a/src/Orb/Handler.hs
+++ b/src/Orb/Handler.hs
@@ -4,6 +4,7 @@ module Orb.Handler
 where
 
 import Orb.Handler.Dispatchable as Export
+import Orb.Handler.Form as Export
 import Orb.Handler.Handler as Export
 import Orb.Handler.PermissionAction as Export
 import Orb.Handler.PermissionError as Export

--- a/src/Orb/Handler/Form.hs
+++ b/src/Orb/Handler/Form.hs
@@ -1,0 +1,57 @@
+module Orb.Handler.Form
+  ( Form
+  , getForm
+  , FormField (..)
+  ) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.List (foldl')
+import Data.List.NonEmpty qualified as NEL
+import Data.Map.Merge.Strict (mergeA, traverseMissing, zipWithAMatched)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Network.Wai.Parse qualified as Wai
+
+type Form = Map.Map T.Text FormField
+
+getForm :: ([Wai.Param], [Wai.File LBS.ByteString]) -> Either T.Text Form
+getForm (params, files) =
+  mergeA
+    (traverseMissing $ \_lk lv -> Right lv)
+    (traverseMissing $ \_rk rv -> Right rv)
+    ( zipWithAMatched $ \k _lv _rv ->
+        Left $
+          T.pack "Form field with name "
+            <> k
+            <> T.pack " appears more than once."
+    )
+    (ParamField <$> foldl' insertParamField Map.empty params)
+    (FileField <$> foldl' insertFileField Map.empty files)
+
+insertParamField ::
+  Map.Map T.Text (NEL.NonEmpty T.Text) ->
+  (BS.ByteString, BS.ByteString) ->
+  Map.Map T.Text (NEL.NonEmpty T.Text)
+insertParamField params (k, v) =
+  Map.insertWith
+    (<>)
+    (TE.decodeUtf8 k)
+    (NEL.singleton $ TE.decodeUtf8 v)
+    params
+
+insertFileField ::
+  Map.Map T.Text (NEL.NonEmpty (Wai.FileInfo LBS.ByteString)) ->
+  (BS.ByteString, Wai.FileInfo LBS.ByteString) ->
+  Map.Map T.Text (NEL.NonEmpty (Wai.FileInfo LBS.ByteString))
+insertFileField files (k, v) =
+  Map.insertWith
+    (<>)
+    (TE.decodeUtf8 k)
+    (NEL.singleton v)
+    files
+
+data FormField
+  = ParamField (NEL.NonEmpty T.Text)
+  | FileField (NEL.NonEmpty (Wai.FileInfo LBS.ByteString))

--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -14,20 +15,21 @@ module Orb.Handler.Handler
   , runHandler
   , HasHandler (..)
   , NoRequestBody (..)
-  , RequestBodySchema (..)
+  , RequestBody (..)
   , useRouteAsPermissionAction
   )
 where
 
+import Data.ByteString.Lazy qualified as LBS
 import Data.Kind qualified as Kind
 import Data.Maybe (maybeToList)
 import Data.Text qualified as T
-import Fleece.Aeson qualified as FA
-import Fleece.Core qualified as FC
 import Network.Wai qualified as Wai
+import Network.Wai.Parse qualified as Wai
 import Shrubbery qualified as S
 import UnliftIO qualified
 
+import Orb.Handler.Form (Form, getForm)
 import Orb.Handler.PermissionAction qualified as PA
 import Orb.Handler.PermissionError qualified as PE
 import Orb.HasRequest qualified as HasRequest
@@ -36,8 +38,8 @@ import Orb.Response qualified as Response
 
 data Handler route = Handler
   { handlerId :: String
-  , requestBodySchema :: RequestBodySchema (HandlerRequestBody route) (HandlerResponses route)
-  , handlerResponseSchemas :: Response.ResponseSchemas (HandlerResponses route)
+  , requestBody :: RequestBody (HandlerRequestBody route) (HandlerResponses route)
+  , handlerResponseBodies :: Response.ResponseBodies (HandlerResponses route)
   , mkPermissionAction ::
       route ->
       HandlerRequestBody route ->
@@ -81,13 +83,17 @@ type HandlerPermissionResult route =
 data NoRequestBody
   = NoRequestBody
 
-data RequestBodySchema body tags where
-  RequestBodySchema ::
-    Response.Has422Response tags =>
-    (forall schema. FC.Fleece schema => schema body) ->
-    RequestBodySchema body tags
-  NoRequestBodySchema ::
-    RequestBodySchema NoRequestBody tags
+data RequestBody body tags where
+  RequestBody ::
+    Response.HasResponseCodeWithType tags "422" err =>
+    (LBS.ByteString -> Either err body) ->
+    RequestBody body tags
+  RequestFormData ::
+    (Response.Has400Response tags, Response.HasResponseCodeWithType tags "422" err) =>
+    (Form -> Either err body) ->
+    RequestBody body tags
+  EmptyRequestBody ::
+    RequestBody NoRequestBody tags
 
 runHandler ::
   ( HasHandler route
@@ -100,16 +106,21 @@ runHandler ::
   route ->
   m Wai.ResponseReceived
 runHandler handler route =
-  case requestBodySchema handler of
-    NoRequestBodySchema ->
-      noRequestBodyHandler
-        (handlerResponseSchemas handler)
-        (runPermissionAction handler route NoRequestBody)
-    RequestBodySchema bodySchema ->
+  case requestBody handler of
+    RequestBody bodyDecoder ->
       requestBodyHandler
-        bodySchema
-        (handlerResponseSchemas handler)
+        bodyDecoder
+        (handlerResponseBodies handler)
         (runPermissionAction handler route)
+    RequestFormData formDecoder ->
+      requestFormDataHandler
+        formDecoder
+        (handlerResponseBodies handler)
+        (runPermissionAction handler route)
+    EmptyRequestBody ->
+      emptyRequestBodyHandler
+        (handlerResponseBodies handler)
+        (runPermissionAction handler route NoRequestBody)
 
 runPermissionAction ::
   (Monad m, HasHandler route, HandlerMonad route ~ m) =>
@@ -128,15 +139,15 @@ runPermissionAction handler route body = do
     Left err -> PE.returnPermissionError err
     Right permissionResult -> handleRequest handler route body permissionResult
 
-noRequestBodyHandler ::
+emptyRequestBodyHandler ::
   ( HasRespond.HasRespond m
   , Response.Has500Response tags
   , UnliftIO.MonadUnliftIO m
   ) =>
-  Response.ResponseSchemas tags ->
+  Response.ResponseBodies tags ->
   m (S.TaggedUnion tags) ->
   m Wai.ResponseReceived
-noRequestBodyHandler schemas action = do
+emptyRequestBodyHandler bodies action = do
   errOrResponse <- UnliftIO.tryAny action
   response <-
     case errOrResponse of
@@ -147,7 +158,7 @@ noRequestBodyHandler schemas action = do
         Response.return500 Response.InternalServerError
 
   let
-    responseData = encodeResponse schemas response
+    responseData = encodeResponse bodies response
     contentTypeHeader =
       maybeToList $
         ("Content-Type",)
@@ -159,27 +170,60 @@ noRequestBodyHandler schemas action = do
       (contentTypeHeader <> Response.responseDataExtraHeaders responseData)
       (Response.responseDataBytes responseData)
 
-requestBodyHandler ::
-  ( Response.Has422Response tags
+requestFormDataHandler ::
+  ( Response.Has400Response tags
+  , Response.HasResponseCodeWithType tags "422" err
   , Response.Has500Response tags
   , HasRequest.HasRequest m
   , HasRespond.HasRespond m
   , UnliftIO.MonadUnliftIO m
   ) =>
-  FA.Decoder request ->
-  Response.ResponseSchemas tags ->
+  (Form -> Either err request) ->
+  Response.ResponseBodies tags ->
   (request -> m (S.TaggedUnion tags)) ->
   m Wai.ResponseReceived
-requestBodyHandler requestDecoder schemas action =
-  noRequestBodyHandler schemas $ do
+requestFormDataHandler requestDecoder bodies action =
+  emptyRequestBodyHandler bodies $ do
+    req <- HasRequest.request
+    errOrFormFields <-
+      UnliftIO.liftIO
+        . UnliftIO.try
+        $ Wai.parseRequestBodyEx
+          Wai.defaultParseRequestBodyOptions
+          Wai.lbsBackEnd
+          req
+
+    case errOrFormFields of
+      Left (err :: Wai.RequestParseException) ->
+        Response.return400 . Response.BadRequestMessage . T.pack $ show err
+      Right formFields ->
+        case getForm formFields of
+          Left err ->
+            Response.return400 $ Response.BadRequestMessage err
+          Right form ->
+            case requestDecoder form of
+              Left err -> Response.return422 err
+              Right request -> action request
+
+requestBodyHandler ::
+  ( Response.HasResponseCodeWithType tags "422" err
+  , Response.Has500Response tags
+  , HasRequest.HasRequest m
+  , HasRespond.HasRespond m
+  , UnliftIO.MonadUnliftIO m
+  ) =>
+  (LBS.ByteString -> Either err request) ->
+  Response.ResponseBodies tags ->
+  (request -> m (S.TaggedUnion tags)) ->
+  m Wai.ResponseReceived
+requestBodyHandler requestDecoder bodies action =
+  emptyRequestBodyHandler bodies $ do
     req <- HasRequest.request
     body <- UnliftIO.liftIO $ Wai.consumeRequestBodyStrict req
-    case FA.decode requestDecoder body of
-      Left err ->
-        Response.return422 . Response.UnprocessableContentMessage . T.pack $ err
-      Right request ->
-        action request
+    case requestDecoder body of
+      Left err -> Response.return422 err
+      Right request -> action request
 
-encodeResponse :: Response.ResponseSchemas tags -> S.TaggedUnion tags -> Response.ResponseData
+encodeResponse :: Response.ResponseBodies tags -> S.TaggedUnion tags -> Response.ResponseData
 encodeResponse =
   S.dissectTaggedUnion . Response.encodeResponseBranches

--- a/src/Orb/Response.hs
+++ b/src/Orb/Response.hs
@@ -3,6 +3,7 @@ module Orb.Response
   )
 where
 
+import Orb.Response.ContentType as Export
 import Orb.Response.Document as Export
 import Orb.Response.HasResponse as Export
 import Orb.Response.Response as Export

--- a/src/Orb/Response/ContentType.hs
+++ b/src/Orb/Response/ContentType.hs
@@ -1,0 +1,268 @@
+module Orb.Response.ContentType
+  ( ContentType
+  , applicationEpubZip
+  , applicationJavaArchive
+  , applicationJson
+  , applicationMsword
+  , applicationOctetStream
+  , applicationPdf
+  , applicationRtf
+  , applicationVndMsExcel
+  , applicationVndMsPowerpoint
+  , applicationX7zCompressed
+  , applicationXRarCompressed
+  , applicationXSh
+  , applicationXTar
+  , applicationXhtmlXml
+  , applicationXml
+  , applicationZip
+  , audioAac
+  , audioMidi
+  , audioWebm
+  , audioXWav
+  , fontTtf
+  , fontWoff
+  , fontWoff2
+  , imageGif
+  , imageJpeg
+  , imageSvgXml
+  , imageTiff
+  , imageWebp
+  , imageXIcon
+  , textCalendar
+  , textCss
+  , textCsv
+  , textHtml
+  , textJavascript
+  , videoMpeg
+  , videoWebm
+  , videoXMsvideo
+  ) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Char8 qualified as BS8
+
+-- | A simple 'BS.ByteString' type alias representing a MIME type.
+type ContentType = BS.ByteString
+
+{- | A 'BS.ByteString' representation of the /application\/epub+zip/ MIME type
+(commonly .epub eBooks).
+-}
+applicationEpubZip :: ContentType
+applicationEpubZip = BS8.pack "application/epub+zip"
+
+{- | A 'BS.ByteString' representation of the /application\/java-archive/ MIME
+type (e.g., .jar files).
+-}
+applicationJavaArchive :: ContentType
+applicationJavaArchive = BS8.pack "application/java-archive"
+
+{- | A 'BS.ByteString' representation of the /application\/json/ MIME type
+(JSON data).
+-}
+applicationJson :: ContentType
+applicationJson = BS8.pack "application/json"
+
+{- | A 'BS.ByteString' representation of the /application\/msword/ MIME type
+(classic .doc files).
+-}
+applicationMsword :: ContentType
+applicationMsword = BS8.pack "application/msword"
+
+{- | A 'BS.ByteString' representation of the /application\/octet-stream/ MIME
+type (generic binary data).
+-}
+applicationOctetStream :: ContentType
+applicationOctetStream = BS8.pack "application/octet-stream"
+
+{- | A 'BS.ByteString' representation of the /application\/pdf/ MIME type (PDF
+documents).
+-}
+applicationPdf :: ContentType
+applicationPdf = BS8.pack "application/pdf"
+
+{- | A 'BS.ByteString' representation of the /application\/rtf/ MIME type (RTF
+documents).
+-}
+applicationRtf :: ContentType
+applicationRtf = BS8.pack "application/rtf"
+
+{- | A 'BS.ByteString' representation of the /application\/vnd.ms-excel/ MIME
+type (older .xls files).
+-}
+applicationVndMsExcel :: ContentType
+applicationVndMsExcel = BS8.pack "application/vnd.ms-excel"
+
+{- | A 'BS.ByteString' representation of the /application\/vnd.ms-powerpoint/
+MIME type (older .ppt files).
+-}
+applicationVndMsPowerpoint :: ContentType
+applicationVndMsPowerpoint = BS8.pack "application/vnd.ms-powerpoint"
+
+{- | A 'BS.ByteString' representation of the /application\/x-7z-compressed/
+MIME type (.7z archives).
+-}
+applicationX7zCompressed :: ContentType
+applicationX7zCompressed = BS8.pack "application/x-7z-compressed"
+
+{- | A 'BS.ByteString' representation of the /application\/x-rar-compressed/
+MIME type (.rar archives).
+-}
+applicationXRarCompressed :: ContentType
+applicationXRarCompressed = BS8.pack "application/x-rar-compressed"
+
+{- | A 'BS.ByteString' representation of the /application\/x-sh/ MIME type (.sh
+shell scripts).
+-}
+applicationXSh :: ContentType
+applicationXSh = BS8.pack "application/x-sh"
+
+{- | A 'BS.ByteString' representation of the /application\/x-tar/ MIME type
+(.tar archives).
+-}
+applicationXTar :: ContentType
+applicationXTar = BS8.pack "application/x-tar"
+
+{- | A 'BS.ByteString' representation of the /application\/xhtml+xml/ MIME type
+(XHTML documents).
+-}
+applicationXhtmlXml :: ContentType
+applicationXhtmlXml = BS8.pack "application/xhtml+xml"
+
+{- | A 'BS.ByteString' representation of the /application\/xml/ MIME type (.xml
+documents).
+-}
+applicationXml :: ContentType
+applicationXml = BS8.pack "application/xml"
+
+{- | A 'BS.ByteString' representation of the /application\/zip/ MIME type (.zip
+archives).
+-}
+applicationZip :: ContentType
+applicationZip = BS8.pack "application/zip"
+
+{- | A 'BS.ByteString' representation of the /audio\/aac/ MIME type (.aac audio
+files).
+-}
+audioAac :: ContentType
+audioAac = BS8.pack "audio/aac"
+
+{- | A 'BS.ByteString' representation of the /audio\/midi/ MIME type (.midi
+music files).
+-}
+audioMidi :: ContentType
+audioMidi = BS8.pack "audio/midi"
+
+{- | A 'BS.ByteString' representation of the /audio\/webm/ MIME type (.weba or
+webm audio).
+-}
+audioWebm :: ContentType
+audioWebm = BS8.pack "audio/webm"
+
+{- | A 'BS.ByteString' representation of the /audio\/x-wav/ MIME type (.wav
+files).
+-}
+audioXWav :: ContentType
+audioXWav = BS8.pack "audio/x-wav"
+
+{- | A 'BS.ByteString' representation of the /font\/ttf/ MIME type (.ttf font
+files).
+-}
+fontTtf :: ContentType
+fontTtf = BS8.pack "font/ttf"
+
+{- | A 'BS.ByteString' representation of the /font\/woff/ MIME type (.woff font
+files).
+-}
+fontWoff :: ContentType
+fontWoff = BS8.pack "font/woff"
+
+{- | A 'BS.ByteString' representation of the /font\/woff2/ MIME type (.woff2
+font files).
+-}
+fontWoff2 :: ContentType
+fontWoff2 = BS8.pack "font/woff2"
+
+{- | A 'BS.ByteString' representation of the /image\/gif/ MIME type (.gif
+images).
+-}
+imageGif :: ContentType
+imageGif = BS8.pack "image/gif"
+
+{- | A 'BS.ByteString' representation of the /image\/jpeg/ MIME type (.jpg or
+.jpeg images).
+-}
+imageJpeg :: ContentType
+imageJpeg = BS8.pack "image/jpeg"
+
+{- | A 'BS.ByteString' representation of the /image\/svg+xml/ MIME type (.svg
+images).
+-}
+imageSvgXml :: ContentType
+imageSvgXml = BS8.pack "image/svg+xml"
+
+{- | A 'BS.ByteString' representation of the /image\/tiff/ MIME type (.tif or
+.tiff images).
+-}
+imageTiff :: ContentType
+imageTiff = BS8.pack "image/tiff"
+
+{- | A 'BS.ByteString' representation of the /image\/webp/ MIME type (.webp
+images).
+-}
+imageWebp :: ContentType
+imageWebp = BS8.pack "image/webp"
+
+{- | A 'BS.ByteString' representation of the /image\/x-icon/ MIME type (.ico
+icons).
+-}
+imageXIcon :: ContentType
+imageXIcon = BS8.pack "image/x-icon"
+
+{- | A 'BS.ByteString' representation of the /text\/calendar/ MIME type (.ics
+calendar files).
+-}
+textCalendar :: ContentType
+textCalendar = BS8.pack "text/calendar"
+
+{- | A 'BS.ByteString' representation of the /text\/css/ MIME type (.css
+stylesheets).
+-}
+textCss :: ContentType
+textCss = BS8.pack "text/css"
+
+{- | A 'BS.ByteString' representation of the /text\/csv/ MIME type (.csv
+spreadsheets).
+-}
+textCsv :: ContentType
+textCsv = BS8.pack "text/csv"
+
+{- | A 'BS.ByteString' representation of the /text\/html/ MIME type (HTML
+documents).
+-}
+textHtml :: ContentType
+textHtml = BS8.pack "text/html"
+
+{- | A 'BS.ByteString' representation of the /text\/javascript/ MIME type (.js
+scripts).
+-}
+textJavascript :: ContentType
+textJavascript = BS8.pack "text/javascript"
+
+{- | A 'BS.ByteString' representation of the /video\/mpeg/ MIME type (.mpeg or
+.mpg videos).
+-}
+videoMpeg :: ContentType
+videoMpeg = BS8.pack "video/mpeg"
+
+{- | A 'BS.ByteString' representation of the /video\/webm/ MIME type (.webm
+videos).
+-}
+videoWebm :: ContentType
+videoWebm = BS8.pack "video/webm"
+
+{- | A 'BS.ByteString' representation of the /video\/x-msvideo/ MIME type (.avi
+videos).
+-}
+videoXMsvideo :: ContentType
+videoXMsvideo = BS8.pack "video/x-msvideo"

--- a/src/Orb/Response/StatusCodes.hs
+++ b/src/Orb/Response/StatusCodes.hs
@@ -9,42 +9,236 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Orb.Response.StatusCodes
-  ( addResponseSchema200
+  ( addResponseSchema100
+  , addResponseSchema101
   , addResponseDocument200
+  , addResponseSchema200
+  , addResponseDocument201
   , addResponseSchema201
+  , addResponseDocument202
+  , addResponseSchema202
+  , addResponseDocument203
+  , addResponseSchema203
   , addResponseSchema204
+  , addResponseSchema205
+  , addResponseDocument206
+  , addResponseSchema206
+  , addResponseDocument300
+  , addResponseSchema300
+  , addResponseDocument301
+  , addResponseSchema301
+  , addResponseDocument302
+  , addResponseSchema302
+  , addResponseDocument303
+  , addResponseSchema303
+  , addResponseSchema304
+  , addResponseDocument305
+  , addResponseSchema305
+  , addResponseDocument307
+  , addResponseSchema307
+  , addResponseDocument308
+  , addResponseSchema308
+  , addResponseDocument400
   , addResponseSchema400
+  , addResponseDocument401
   , addResponseSchema401
+  , addResponseDocument402
+  , addResponseSchema402
+  , addResponseDocument403
   , addResponseSchema403
+  , addResponseDocument404
   , addResponseSchema404
+  , addResponseDocument405
+  , addResponseSchema405
+  , addResponseDocument406
+  , addResponseSchema406
+  , addResponseDocument407
+  , addResponseSchema407
+  , addResponseDocument408
+  , addResponseSchema408
+  , addResponseDocument409
   , addResponseSchema409
+  , addResponseDocument410
+  , addResponseSchema410
+  , addResponseDocument411
+  , addResponseSchema411
+  , addResponseDocument412
+  , addResponseSchema412
+  , addResponseDocument413
+  , addResponseSchema413
+  , addResponseDocument414
+  , addResponseSchema414
+  , addResponseDocument415
+  , addResponseSchema415
+  , addResponseDocument416
+  , addResponseSchema416
+  , addResponseDocument417
+  , addResponseSchema417
+  , addResponseDocument418
+  , addResponseSchema418
+  , addResponseDocument422
   , addResponseSchema422
+  , addResponseDocument428
+  , addResponseSchema428
+  , addResponseDocument429
+  , addResponseSchema429
+  , addResponseDocument431
+  , addResponseSchema431
+  , addResponseDocument500
   , addResponseSchema500
+  , addResponseDocument501
+  , addResponseSchema501
+  , addResponseDocument502
+  , addResponseSchema502
+  , addResponseDocument503
   , addResponseSchema503
+  , addResponseDocument504
+  , addResponseSchema504
+  , addResponseDocument505
+  , addResponseSchema505
+  , addResponseDocument511
+  , addResponseSchema511
+  , Response100
+  , Response101
   , Response200
   , Response201
+  , Response202
+  , Response203
   , Response204
+  , Response205
+  , Response206
+  , Response300
+  , Response301
+  , Response302
+  , Response303
+  , Response304
+  , Response305
+  , Response307
+  , Response308
   , Response400
   , Response401
+  , Response402
   , Response403
   , Response404
+  , Response405
+  , Response406
+  , Response407
+  , Response408
   , Response409
+  , Response410
+  , Response411
+  , Response412
+  , Response413
+  , Response414
+  , Response415
+  , Response416
+  , Response417
+  , Response418
   , Response422
+  , Response428
+  , Response429
+  , Response431
   , Response500
+  , Response501
+  , Response502
   , Response503
+  , Response504
+  , Response505
+  , Response511
+  , return100
+  , return100WithHeaders
+  , return101
+  , return101WithHeaders
   , return200
+  , return200WithHeaders
   , return201
   , return201WithHeaders
+  , return202
+  , return202WithHeaders
+  , return203
+  , return203WithHeaders
   , return204
   , return204WithHeaders
+  , return205
+  , return205WithHeaders
+  , return206
+  , return206WithHeaders
+  , return300
+  , return300WithHeaders
+  , return301
+  , return301WithHeaders
+  , return302
+  , return302WithHeaders
+  , return303
+  , return303WithHeaders
+  , return304
+  , return304WithHeaders
+  , return305
+  , return305WithHeaders
+  , return307
+  , return307WithHeaders
+  , return308
+  , return308WithHeaders
   , return400
+  , return400WithHeaders
   , return401
+  , return401WithHeaders
+  , return402
+  , return402WithHeaders
   , return403
+  , return403WithHeaders
   , return404
+  , return404WithHeaders
+  , return405
+  , return405WithHeaders
+  , return406
+  , return406WithHeaders
+  , return407
+  , return407WithHeaders
+  , return408
+  , return408WithHeaders
   , return409
+  , return409WithHeaders
+  , return410
+  , return410WithHeaders
+  , return411
+  , return411WithHeaders
+  , return412
+  , return412WithHeaders
+  , return413
+  , return413WithHeaders
+  , return414
+  , return414WithHeaders
+  , return415
+  , return415WithHeaders
+  , return416
+  , return416WithHeaders
+  , return417
+  , return417WithHeaders
+  , return418
+  , return418WithHeaders
   , return422
+  , return422WithHeaders
+  , return428
+  , return428WithHeaders
+  , return429
+  , return429WithHeaders
+  , return431
+  , return431WithHeaders
   , return500
+  , return500WithHeaders
+  , return501
+  , return501WithHeaders
+  , return502
+  , return502WithHeaders
   , return503
+  , return503WithHeaders
+  , return504
+  , return504WithHeaders
+  , return505
+  , return505WithHeaders
+  , return511
+  , return511WithHeaders
   )
 where
 
@@ -59,7 +253,7 @@ import Shrubbery qualified as S
 
 import Orb.Response.Document (Document (..))
 import Orb.Response.Response (ResponseData (..), ResponseSchema (..), ResponseSchemasBuilder (..))
-import Orb.Response.Schemas (NoContent)
+import Orb.Response.Schemas (NoContent (..))
 
 addResponseSchema ::
   forall tag tags a.
@@ -153,17 +347,65 @@ addNoResponseSchema builder =
 class KnownHTTPStatus tag where
   httpStatusVal :: proxy tag -> HTTP.Status
 
+type Response100 = "100" @= (NoContent, HTTP.ResponseHeaders)
+type Response101 = "101" @= (NoContent, HTTP.ResponseHeaders)
 type Response200 a = "200" @= (a, HTTP.ResponseHeaders)
 type Response201 a = "201" @= (a, HTTP.ResponseHeaders)
+type Response202 a = "202" @= (a, HTTP.ResponseHeaders)
+type Response203 a = "203" @= (a, HTTP.ResponseHeaders)
 type Response204 = "204" @= (NoContent, HTTP.ResponseHeaders)
+type Response205 = "205" @= (NoContent, HTTP.ResponseHeaders)
+type Response206 a = "206" @= (a, HTTP.ResponseHeaders)
+type Response300 a = "300" @= (a, HTTP.ResponseHeaders)
+type Response301 a = "301" @= (a, HTTP.ResponseHeaders)
+type Response302 a = "302" @= (a, HTTP.ResponseHeaders)
+type Response303 a = "303" @= (a, HTTP.ResponseHeaders)
+type Response304 = "304" @= (NoContent, HTTP.ResponseHeaders)
+type Response305 a = "305" @= (a, HTTP.ResponseHeaders)
+type Response307 a = "307" @= (a, HTTP.ResponseHeaders)
+type Response308 a = "308" @= (a, HTTP.ResponseHeaders)
 type Response400 a = "400" @= (a, HTTP.ResponseHeaders)
 type Response401 a = "401" @= (a, HTTP.ResponseHeaders)
+type Response402 a = "402" @= (a, HTTP.ResponseHeaders)
 type Response403 a = "403" @= (a, HTTP.ResponseHeaders)
 type Response404 a = "404" @= (a, HTTP.ResponseHeaders)
+type Response405 a = "405" @= (a, HTTP.ResponseHeaders)
+type Response406 a = "406" @= (a, HTTP.ResponseHeaders)
+type Response407 a = "407" @= (a, HTTP.ResponseHeaders)
+type Response408 a = "408" @= (a, HTTP.ResponseHeaders)
 type Response409 a = "409" @= (a, HTTP.ResponseHeaders)
+type Response410 a = "410" @= (a, HTTP.ResponseHeaders)
+type Response411 a = "411" @= (a, HTTP.ResponseHeaders)
+type Response412 a = "412" @= (a, HTTP.ResponseHeaders)
+type Response413 a = "413" @= (a, HTTP.ResponseHeaders)
+type Response414 a = "414" @= (a, HTTP.ResponseHeaders)
+type Response415 a = "415" @= (a, HTTP.ResponseHeaders)
+type Response416 a = "416" @= (a, HTTP.ResponseHeaders)
+type Response417 a = "417" @= (a, HTTP.ResponseHeaders)
+type Response418 a = "418" @= (a, HTTP.ResponseHeaders)
 type Response422 a = "422" @= (a, HTTP.ResponseHeaders)
+type Response428 a = "428" @= (a, HTTP.ResponseHeaders)
+type Response429 a = "429" @= (a, HTTP.ResponseHeaders)
+type Response431 a = "431" @= (a, HTTP.ResponseHeaders)
 type Response500 a = "500" @= (a, HTTP.ResponseHeaders)
+type Response501 a = "501" @= (a, HTTP.ResponseHeaders)
+type Response502 a = "502" @= (a, HTTP.ResponseHeaders)
 type Response503 a = "503" @= (a, HTTP.ResponseHeaders)
+type Response504 a = "504" @= (a, HTTP.ResponseHeaders)
+type Response505 a = "505" @= (a, HTTP.ResponseHeaders)
+type Response511 a = "511" @= (a, HTTP.ResponseHeaders)
+
+addResponseSchema100 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response100 : tags)
+addResponseSchema100 =
+  addNoResponseSchema @"100"
+
+addResponseSchema101 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response101 : tags)
+addResponseSchema101 =
+  addNoResponseSchema @"101"
 
 addResponseSchema200 ::
   (forall schema. FC.Fleece schema => schema a) ->
@@ -185,11 +427,159 @@ addResponseSchema201 ::
 addResponseSchema201 =
   addResponseSchema @"201"
 
+addResponseDocument201 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response201 Document : tags)
+addResponseDocument201 =
+  addResponseDocument @"201"
+
+addResponseSchema202 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response202 a : tags)
+addResponseSchema202 =
+  addResponseSchema @"202"
+
+addResponseDocument202 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response202 Document : tags)
+addResponseDocument202 =
+  addResponseDocument @"202"
+
+addResponseSchema203 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response203 a : tags)
+addResponseSchema203 =
+  addResponseSchema @"203"
+
+addResponseDocument203 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response203 Document : tags)
+addResponseDocument203 =
+  addResponseDocument @"203"
+
 addResponseSchema204 ::
   ResponseSchemasBuilder tags ->
   ResponseSchemasBuilder (Response204 : tags)
 addResponseSchema204 =
   addNoResponseSchema @"204"
+
+addResponseSchema205 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response205 : tags)
+addResponseSchema205 =
+  addNoResponseSchema @"205"
+
+addResponseSchema206 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response206 a : tags)
+addResponseSchema206 =
+  addResponseSchema @"206"
+
+addResponseDocument206 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response206 Document : tags)
+addResponseDocument206 =
+  addResponseDocument @"206"
+
+addResponseSchema300 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response300 a : tags)
+addResponseSchema300 =
+  addResponseSchema @"300"
+
+addResponseDocument300 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response300 Document : tags)
+addResponseDocument300 =
+  addResponseDocument @"300"
+
+addResponseSchema301 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response301 a : tags)
+addResponseSchema301 =
+  addResponseSchema @"301"
+
+addResponseDocument301 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response301 Document : tags)
+addResponseDocument301 =
+  addResponseDocument @"301"
+
+addResponseSchema302 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response302 a : tags)
+addResponseSchema302 =
+  addResponseSchema @"302"
+
+addResponseDocument302 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response302 Document : tags)
+addResponseDocument302 =
+  addResponseDocument @"302"
+
+addResponseSchema303 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response303 a : tags)
+addResponseSchema303 =
+  addResponseSchema @"303"
+
+addResponseDocument303 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response303 Document : tags)
+addResponseDocument303 =
+  addResponseDocument @"303"
+
+addResponseSchema304 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response304 : tags)
+addResponseSchema304 =
+  addNoResponseSchema @"304"
+
+addResponseSchema305 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response305 a : tags)
+addResponseSchema305 =
+  addResponseSchema @"305"
+
+addResponseDocument305 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response305 Document : tags)
+addResponseDocument305 =
+  addResponseDocument @"305"
+
+addResponseSchema307 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response307 a : tags)
+addResponseSchema307 =
+  addResponseSchema @"307"
+
+addResponseDocument307 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response307 Document : tags)
+addResponseDocument307 =
+  addResponseDocument @"307"
+
+addResponseSchema308 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response308 a : tags)
+addResponseSchema308 =
+  addResponseSchema @"308"
+
+addResponseDocument308 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response308 Document : tags)
+addResponseDocument308 =
+  addResponseDocument @"308"
 
 addResponseSchema400 ::
   (forall schema. FC.Fleece schema => schema a) ->
@@ -198,12 +588,37 @@ addResponseSchema400 ::
 addResponseSchema400 =
   addResponseSchema @"400"
 
+addResponseDocument400 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response400 Document : tags)
+addResponseDocument400 =
+  addResponseDocument @"400"
+
 addResponseSchema401 ::
   (forall schema. FC.Fleece schema => schema a) ->
   ResponseSchemasBuilder tags ->
   ResponseSchemasBuilder (Response401 a : tags)
 addResponseSchema401 =
   addResponseSchema @"401"
+
+addResponseDocument401 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response401 Document : tags)
+addResponseDocument401 =
+  addResponseDocument @"401"
+
+addResponseSchema402 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response402 a : tags)
+addResponseSchema402 =
+  addResponseSchema @"402"
+
+addResponseDocument402 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response402 Document : tags)
+addResponseDocument402 =
+  addResponseDocument @"402"
 
 addResponseSchema403 ::
   (forall schema. FC.Fleece schema => schema a) ->
@@ -212,12 +627,76 @@ addResponseSchema403 ::
 addResponseSchema403 =
   addResponseSchema @"403"
 
+addResponseDocument403 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response403 Document : tags)
+addResponseDocument403 =
+  addResponseDocument @"403"
+
 addResponseSchema404 ::
   (forall schema. FC.Fleece schema => schema a) ->
   ResponseSchemasBuilder tags ->
   ResponseSchemasBuilder (Response404 a : tags)
 addResponseSchema404 =
   addResponseSchema @"404"
+
+addResponseDocument404 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response404 Document : tags)
+addResponseDocument404 =
+  addResponseDocument @"404"
+
+addResponseSchema405 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response405 a : tags)
+addResponseSchema405 =
+  addResponseSchema @"405"
+
+addResponseDocument405 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response405 Document : tags)
+addResponseDocument405 =
+  addResponseDocument @"405"
+
+addResponseSchema406 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response406 a : tags)
+addResponseSchema406 =
+  addResponseSchema @"406"
+
+addResponseDocument406 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response406 Document : tags)
+addResponseDocument406 =
+  addResponseDocument @"406"
+
+addResponseSchema407 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response407 a : tags)
+addResponseSchema407 =
+  addResponseSchema @"407"
+
+addResponseDocument407 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response407 Document : tags)
+addResponseDocument407 =
+  addResponseDocument @"407"
+
+addResponseSchema408 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response408 a : tags)
+addResponseSchema408 =
+  addResponseSchema @"408"
+
+addResponseDocument408 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response408 Document : tags)
+addResponseDocument408 =
+  addResponseDocument @"408"
 
 addResponseSchema409 ::
   (forall schema. FC.Fleece schema => schema a) ->
@@ -226,12 +705,180 @@ addResponseSchema409 ::
 addResponseSchema409 =
   addResponseSchema @"409"
 
+addResponseDocument409 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response409 Document : tags)
+addResponseDocument409 =
+  addResponseDocument @"409"
+
+addResponseSchema410 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response410 a : tags)
+addResponseSchema410 =
+  addResponseSchema @"410"
+
+addResponseDocument410 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response410 Document : tags)
+addResponseDocument410 =
+  addResponseDocument @"410"
+
+addResponseSchema411 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response411 a : tags)
+addResponseSchema411 =
+  addResponseSchema @"411"
+
+addResponseDocument411 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response411 Document : tags)
+addResponseDocument411 =
+  addResponseDocument @"411"
+
+addResponseSchema412 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response412 a : tags)
+addResponseSchema412 =
+  addResponseSchema @"412"
+
+addResponseDocument412 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response412 Document : tags)
+addResponseDocument412 =
+  addResponseDocument @"412"
+
+addResponseSchema413 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response413 a : tags)
+addResponseSchema413 =
+  addResponseSchema @"413"
+
+addResponseDocument413 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response413 Document : tags)
+addResponseDocument413 =
+  addResponseDocument @"413"
+
+addResponseSchema414 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response414 a : tags)
+addResponseSchema414 =
+  addResponseSchema @"414"
+
+addResponseDocument414 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response414 Document : tags)
+addResponseDocument414 =
+  addResponseDocument @"414"
+
+addResponseSchema415 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response415 a : tags)
+addResponseSchema415 =
+  addResponseSchema @"415"
+
+addResponseDocument415 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response415 Document : tags)
+addResponseDocument415 =
+  addResponseDocument @"415"
+
+addResponseSchema416 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response416 a : tags)
+addResponseSchema416 =
+  addResponseSchema @"416"
+
+addResponseDocument416 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response416 Document : tags)
+addResponseDocument416 =
+  addResponseDocument @"416"
+
+addResponseSchema417 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response417 a : tags)
+addResponseSchema417 =
+  addResponseSchema @"417"
+
+addResponseDocument417 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response417 Document : tags)
+addResponseDocument417 =
+  addResponseDocument @"417"
+
+addResponseSchema418 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response418 a : tags)
+addResponseSchema418 =
+  addResponseSchema @"418"
+
+addResponseDocument418 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response418 Document : tags)
+addResponseDocument418 =
+  addResponseDocument @"418"
+
 addResponseSchema422 ::
   (forall schema. FC.Fleece schema => schema a) ->
   ResponseSchemasBuilder tags ->
   ResponseSchemasBuilder (Response422 a : tags)
 addResponseSchema422 =
   addResponseSchema @"422"
+
+addResponseDocument422 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response422 Document : tags)
+addResponseDocument422 =
+  addResponseDocument @"422"
+
+addResponseSchema428 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response428 a : tags)
+addResponseSchema428 =
+  addResponseSchema @"428"
+
+addResponseDocument428 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response428 Document : tags)
+addResponseDocument428 =
+  addResponseDocument @"428"
+
+addResponseSchema429 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response429 a : tags)
+addResponseSchema429 =
+  addResponseSchema @"429"
+
+addResponseDocument429 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response429 Document : tags)
+addResponseDocument429 =
+  addResponseDocument @"429"
+
+addResponseSchema431 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response431 a : tags)
+addResponseSchema431 =
+  addResponseSchema @"431"
+
+addResponseDocument431 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response431 Document : tags)
+addResponseDocument431 =
+  addResponseDocument @"431"
 
 addResponseSchema500 ::
   (forall schema. FC.Fleece schema => schema a) ->
@@ -240,6 +887,38 @@ addResponseSchema500 ::
 addResponseSchema500 =
   addResponseSchema @"500"
 
+addResponseDocument500 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response500 Document : tags)
+addResponseDocument500 =
+  addResponseDocument @"500"
+
+addResponseSchema501 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response501 a : tags)
+addResponseSchema501 =
+  addResponseSchema @"501"
+
+addResponseDocument501 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response501 Document : tags)
+addResponseDocument501 =
+  addResponseDocument @"501"
+
+addResponseSchema502 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response502 a : tags)
+addResponseSchema502 =
+  addResponseSchema @"502"
+
+addResponseDocument502 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response502 Document : tags)
+addResponseDocument502 =
+  addResponseDocument @"502"
+
 addResponseSchema503 ::
   (forall schema. FC.Fleece schema => schema a) ->
   ResponseSchemasBuilder tags ->
@@ -247,14 +926,101 @@ addResponseSchema503 ::
 addResponseSchema503 =
   addResponseSchema @"503"
 
+addResponseDocument503 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response503 Document : tags)
+addResponseDocument503 =
+  addResponseDocument @"503"
+
+addResponseSchema504 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response504 a : tags)
+addResponseSchema504 =
+  addResponseSchema @"504"
+
+addResponseDocument504 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response504 Document : tags)
+addResponseDocument504 =
+  addResponseDocument @"504"
+
+addResponseSchema505 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response505 a : tags)
+addResponseSchema505 =
+  addResponseSchema @"505"
+
+addResponseDocument505 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response505 Document : tags)
+addResponseDocument505 =
+  addResponseDocument @"505"
+
+addResponseSchema511 ::
+  (forall schema. FC.Fleece schema => schema a) ->
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response511 a : tags)
+addResponseSchema511 =
+  addResponseSchema @"511"
+
+addResponseDocument511 ::
+  ResponseSchemasBuilder tags ->
+  ResponseSchemasBuilder (Response511 Document : tags)
+addResponseDocument511 =
+  addResponseDocument @"511"
+
+instance KnownHTTPStatus "100" where
+  httpStatusVal _ = HTTP.status100
+
+instance KnownHTTPStatus "101" where
+  httpStatusVal _ = HTTP.status101
+
 instance KnownHTTPStatus "200" where
   httpStatusVal _ = HTTP.status200
 
 instance KnownHTTPStatus "201" where
   httpStatusVal _ = HTTP.status201
 
+instance KnownHTTPStatus "202" where
+  httpStatusVal _ = HTTP.status202
+
+instance KnownHTTPStatus "203" where
+  httpStatusVal _ = HTTP.status203
+
 instance KnownHTTPStatus "204" where
   httpStatusVal _ = HTTP.status204
+
+instance KnownHTTPStatus "205" where
+  httpStatusVal _ = HTTP.status205
+
+instance KnownHTTPStatus "206" where
+  httpStatusVal _ = HTTP.status206
+
+instance KnownHTTPStatus "300" where
+  httpStatusVal _ = HTTP.status300
+
+instance KnownHTTPStatus "301" where
+  httpStatusVal _ = HTTP.status301
+
+instance KnownHTTPStatus "302" where
+  httpStatusVal _ = HTTP.status302
+
+instance KnownHTTPStatus "303" where
+  httpStatusVal _ = HTTP.status303
+
+instance KnownHTTPStatus "304" where
+  httpStatusVal _ = HTTP.status304
+
+instance KnownHTTPStatus "305" where
+  httpStatusVal _ = HTTP.status305
+
+instance KnownHTTPStatus "307" where
+  httpStatusVal _ = HTTP.status307
+
+instance KnownHTTPStatus "308" where
+  httpStatusVal _ = HTTP.status308
 
 instance KnownHTTPStatus "400" where
   httpStatusVal _ = HTTP.status400
@@ -262,23 +1028,89 @@ instance KnownHTTPStatus "400" where
 instance KnownHTTPStatus "401" where
   httpStatusVal _ = HTTP.status401
 
+instance KnownHTTPStatus "402" where
+  httpStatusVal _ = HTTP.status402
+
 instance KnownHTTPStatus "403" where
   httpStatusVal _ = HTTP.status403
 
 instance KnownHTTPStatus "404" where
   httpStatusVal _ = HTTP.status404
 
+instance KnownHTTPStatus "405" where
+  httpStatusVal _ = HTTP.status405
+
+instance KnownHTTPStatus "406" where
+  httpStatusVal _ = HTTP.status406
+
+instance KnownHTTPStatus "407" where
+  httpStatusVal _ = HTTP.status407
+
+instance KnownHTTPStatus "408" where
+  httpStatusVal _ = HTTP.status408
+
 instance KnownHTTPStatus "409" where
   httpStatusVal _ = HTTP.status409
+
+instance KnownHTTPStatus "410" where
+  httpStatusVal _ = HTTP.status410
+
+instance KnownHTTPStatus "411" where
+  httpStatusVal _ = HTTP.status411
+
+instance KnownHTTPStatus "412" where
+  httpStatusVal _ = HTTP.status412
+
+instance KnownHTTPStatus "413" where
+  httpStatusVal _ = HTTP.status413
+
+instance KnownHTTPStatus "414" where
+  httpStatusVal _ = HTTP.status414
+
+instance KnownHTTPStatus "415" where
+  httpStatusVal _ = HTTP.status415
+
+instance KnownHTTPStatus "416" where
+  httpStatusVal _ = HTTP.status416
+
+instance KnownHTTPStatus "417" where
+  httpStatusVal _ = HTTP.status417
+
+instance KnownHTTPStatus "418" where
+  httpStatusVal _ = HTTP.status418
 
 instance KnownHTTPStatus "422" where
   httpStatusVal _ = HTTP.status422
 
+instance KnownHTTPStatus "428" where
+  httpStatusVal _ = HTTP.status428
+
+instance KnownHTTPStatus "429" where
+  httpStatusVal _ = HTTP.status429
+
+instance KnownHTTPStatus "431" where
+  httpStatusVal _ = HTTP.status431
+
 instance KnownHTTPStatus "500" where
   httpStatusVal _ = HTTP.status500
 
+instance KnownHTTPStatus "501" where
+  httpStatusVal _ = HTTP.status501
+
+instance KnownHTTPStatus "502" where
+  httpStatusVal _ = HTTP.status502
+
 instance KnownHTTPStatus "503" where
   httpStatusVal _ = HTTP.status503
+
+instance KnownHTTPStatus "504" where
+  httpStatusVal _ = HTTP.status504
+
+instance KnownHTTPStatus "505" where
+  httpStatusVal _ = HTTP.status505
+
+instance KnownHTTPStatus "511" where
+  httpStatusVal _ = HTTP.status511
 
 type ReturnType a n m tags code =
   ( (a, HTTP.ResponseHeaders) ~ S.TagType code tags
@@ -290,20 +1122,74 @@ type ReturnType a n m tags code =
   a ->
   m (S.TaggedUnion tags)
 
+type Return100 n m tags = ReturnType NoContent n m tags "100"
+type Return101 n m tags = ReturnType NoContent n m tags "101"
 type Return200 a n m tags = ReturnType a n m tags "200"
 type Return201 a n m tags = ReturnType a n m tags "201"
+type Return202 a n m tags = ReturnType a n m tags "202"
+type Return203 a n m tags = ReturnType a n m tags "203"
 type Return204 n m tags = ReturnType NoContent n m tags "204"
+type Return205 n m tags = ReturnType NoContent n m tags "205"
+type Return206 a n m tags = ReturnType a n m tags "206"
+type Return300 a n m tags = ReturnType a n m tags "300"
+type Return301 a n m tags = ReturnType a n m tags "301"
+type Return302 a n m tags = ReturnType a n m tags "302"
+type Return303 a n m tags = ReturnType a n m tags "303"
+type Return304 n m tags = ReturnType NoContent n m tags "304"
+type Return305 a n m tags = ReturnType a n m tags "305"
+type Return307 a n m tags = ReturnType a n m tags "307"
+type Return308 a n m tags = ReturnType a n m tags "308"
 type Return400 a n m tags = ReturnType a n m tags "400"
 type Return401 a n m tags = ReturnType a n m tags "401"
+type Return402 a n m tags = ReturnType a n m tags "402"
 type Return403 a n m tags = ReturnType a n m tags "403"
 type Return404 a n m tags = ReturnType a n m tags "404"
+type Return405 a n m tags = ReturnType a n m tags "405"
+type Return406 a n m tags = ReturnType a n m tags "406"
+type Return407 a n m tags = ReturnType a n m tags "407"
+type Return408 a n m tags = ReturnType a n m tags "408"
 type Return409 a n m tags = ReturnType a n m tags "409"
+type Return410 a n m tags = ReturnType a n m tags "410"
+type Return411 a n m tags = ReturnType a n m tags "411"
+type Return412 a n m tags = ReturnType a n m tags "412"
+type Return413 a n m tags = ReturnType a n m tags "413"
+type Return414 a n m tags = ReturnType a n m tags "414"
+type Return415 a n m tags = ReturnType a n m tags "415"
+type Return416 a n m tags = ReturnType a n m tags "416"
+type Return417 a n m tags = ReturnType a n m tags "417"
+type Return418 a n m tags = ReturnType a n m tags "418"
 type Return422 a n m tags = ReturnType a n m tags "422"
+type Return428 a n m tags = ReturnType a n m tags "428"
+type Return429 a n m tags = ReturnType a n m tags "429"
+type Return431 a n m tags = ReturnType a n m tags "431"
 type Return500 a n m tags = ReturnType a n m tags "500"
+type Return501 a n m tags = ReturnType a n m tags "501"
+type Return502 a n m tags = ReturnType a n m tags "502"
 type Return503 a n m tags = ReturnType a n m tags "503"
+type Return504 a n m tags = ReturnType a n m tags "504"
+type Return505 a n m tags = ReturnType a n m tags "505"
+type Return511 a n m tags = ReturnType a n m tags "511"
+
+return100 :: Return100 n m tags
+return100 = return100WithHeaders []
+
+return100WithHeaders :: HTTP.ResponseHeaders -> Return100 n m tags
+return100WithHeaders headers =
+  pure . S.unifyTaggedUnion @"100" . (,headers)
+
+return101 :: Return101 n m tags
+return101 = return101WithHeaders []
+
+return101WithHeaders :: HTTP.ResponseHeaders -> Return101 n m tags
+return101WithHeaders headers =
+  pure . S.unifyTaggedUnion @"101" . (,headers)
 
 return200 :: Return200 a n m tags
-return200 = pure . S.unifyTaggedUnion @"200" . (,[])
+return200 = return200WithHeaders []
+
+return200WithHeaders :: HTTP.ResponseHeaders -> Return200 a n m tags
+return200WithHeaders headers =
+  pure . S.unifyTaggedUnion @"200" . (,headers)
 
 return201 :: Return201 a n m tags
 return201 = return201WithHeaders []
@@ -312,6 +1198,20 @@ return201WithHeaders :: HTTP.ResponseHeaders -> Return201 a n m tags
 return201WithHeaders headers =
   pure . S.unifyTaggedUnion @"201" . (,headers)
 
+return202 :: Return202 a n m tags
+return202 = return202WithHeaders []
+
+return202WithHeaders :: HTTP.ResponseHeaders -> Return202 a n m tags
+return202WithHeaders headers =
+  pure . S.unifyTaggedUnion @"202" . (,headers)
+
+return203 :: Return203 a n m tags
+return203 = return203WithHeaders []
+
+return203WithHeaders :: HTTP.ResponseHeaders -> Return203 a n m tags
+return203WithHeaders headers =
+  pure . S.unifyTaggedUnion @"203" . (,headers)
+
 return204 :: Return204 n m tags
 return204 = return204WithHeaders []
 
@@ -319,26 +1219,282 @@ return204WithHeaders :: HTTP.ResponseHeaders -> Return204 n m tags
 return204WithHeaders headers =
   pure . S.unifyTaggedUnion @"204" . (,headers)
 
+return205 :: Return205 n m tags
+return205 = return205WithHeaders []
+
+return205WithHeaders :: HTTP.ResponseHeaders -> Return205 n m tags
+return205WithHeaders headers =
+  pure . S.unifyTaggedUnion @"205" . (,headers)
+
+return206 :: Return206 a n m tags
+return206 = return206WithHeaders []
+
+return206WithHeaders :: HTTP.ResponseHeaders -> Return206 a n m tags
+return206WithHeaders headers =
+  pure . S.unifyTaggedUnion @"206" . (,headers)
+
+return300 :: Return300 a n m tags
+return300 = return300WithHeaders []
+
+return300WithHeaders :: HTTP.ResponseHeaders -> Return300 a n m tags
+return300WithHeaders headers =
+  pure . S.unifyTaggedUnion @"300" . (,headers)
+
+return301 :: Return301 a n m tags
+return301 = return301WithHeaders []
+
+return301WithHeaders :: HTTP.ResponseHeaders -> Return301 a n m tags
+return301WithHeaders headers =
+  pure . S.unifyTaggedUnion @"301" . (,headers)
+
+return302 :: Return302 a n m tags
+return302 = return302WithHeaders []
+
+return302WithHeaders :: HTTP.ResponseHeaders -> Return302 a n m tags
+return302WithHeaders headers =
+  pure . S.unifyTaggedUnion @"302" . (,headers)
+
+return303 :: Return303 a n m tags
+return303 = return303WithHeaders []
+
+return303WithHeaders :: HTTP.ResponseHeaders -> Return303 a n m tags
+return303WithHeaders headers =
+  pure . S.unifyTaggedUnion @"303" . (,headers)
+
+return304 :: Return304 n m tags
+return304 = return304WithHeaders []
+
+return304WithHeaders :: HTTP.ResponseHeaders -> Return304 n m tags
+return304WithHeaders headers =
+  pure . S.unifyTaggedUnion @"304" . (,headers)
+
+return305 :: Return305 a n m tags
+return305 = return305WithHeaders []
+
+return305WithHeaders :: HTTP.ResponseHeaders -> Return305 a n m tags
+return305WithHeaders headers =
+  pure . S.unifyTaggedUnion @"305" . (,headers)
+
+return307 :: Return307 a n m tags
+return307 = return307WithHeaders []
+
+return307WithHeaders :: HTTP.ResponseHeaders -> Return307 a n m tags
+return307WithHeaders headers =
+  pure . S.unifyTaggedUnion @"307" . (,headers)
+
+return308 :: Return308 a n m tags
+return308 = return308WithHeaders []
+
+return308WithHeaders :: HTTP.ResponseHeaders -> Return308 a n m tags
+return308WithHeaders headers =
+  pure . S.unifyTaggedUnion @"308" . (,headers)
+
 return400 :: Return400 a n m tags
-return400 = pure . S.unifyTaggedUnion @"400" . (,[])
+return400 = return400WithHeaders []
+
+return400WithHeaders :: HTTP.ResponseHeaders -> Return400 a n m tags
+return400WithHeaders headers =
+  pure . S.unifyTaggedUnion @"400" . (,headers)
 
 return401 :: Return401 a n m tags
-return401 = pure . S.unifyTaggedUnion @"401" . (,[])
+return401 = return401WithHeaders []
+
+return401WithHeaders :: HTTP.ResponseHeaders -> Return401 a n m tags
+return401WithHeaders headers =
+  pure . S.unifyTaggedUnion @"401" . (,headers)
+
+return402 :: Return402 a n m tags
+return402 = return402WithHeaders []
+
+return402WithHeaders :: HTTP.ResponseHeaders -> Return402 a n m tags
+return402WithHeaders headers =
+  pure . S.unifyTaggedUnion @"402" . (,headers)
 
 return403 :: Return403 a n m tags
-return403 = pure . S.unifyTaggedUnion @"403" . (,[])
+return403 = return403WithHeaders []
+
+return403WithHeaders :: HTTP.ResponseHeaders -> Return403 a n m tags
+return403WithHeaders headers =
+  pure . S.unifyTaggedUnion @"403" . (,headers)
 
 return404 :: Return404 a n m tags
-return404 = pure . S.unifyTaggedUnion @"404" . (,[])
+return404 = return404WithHeaders []
+
+return404WithHeaders :: HTTP.ResponseHeaders -> Return404 a n m tags
+return404WithHeaders headers =
+  pure . S.unifyTaggedUnion @"404" . (,headers)
+
+return405 :: Return405 a n m tags
+return405 = return405WithHeaders []
+
+return405WithHeaders :: HTTP.ResponseHeaders -> Return405 a n m tags
+return405WithHeaders headers =
+  pure . S.unifyTaggedUnion @"405" . (,headers)
+
+return406 :: Return406 a n m tags
+return406 = return406WithHeaders []
+
+return406WithHeaders :: HTTP.ResponseHeaders -> Return406 a n m tags
+return406WithHeaders headers =
+  pure . S.unifyTaggedUnion @"406" . (,headers)
+
+return407 :: Return407 a n m tags
+return407 = return407WithHeaders []
+
+return407WithHeaders :: HTTP.ResponseHeaders -> Return407 a n m tags
+return407WithHeaders headers =
+  pure . S.unifyTaggedUnion @"407" . (,headers)
+
+return408 :: Return408 a n m tags
+return408 = return408WithHeaders []
+
+return408WithHeaders :: HTTP.ResponseHeaders -> Return408 a n m tags
+return408WithHeaders headers =
+  pure . S.unifyTaggedUnion @"408" . (,headers)
 
 return409 :: Return409 a n m tags
-return409 = pure . S.unifyTaggedUnion @"409" . (,[])
+return409 = return409WithHeaders []
+
+return409WithHeaders :: HTTP.ResponseHeaders -> Return409 a n m tags
+return409WithHeaders headers =
+  pure . S.unifyTaggedUnion @"409" . (,headers)
+
+return410 :: Return410 a n m tags
+return410 = return410WithHeaders []
+
+return410WithHeaders :: HTTP.ResponseHeaders -> Return410 a n m tags
+return410WithHeaders headers =
+  pure . S.unifyTaggedUnion @"410" . (,headers)
+
+return411 :: Return411 a n m tags
+return411 = return411WithHeaders []
+
+return411WithHeaders :: HTTP.ResponseHeaders -> Return411 a n m tags
+return411WithHeaders headers =
+  pure . S.unifyTaggedUnion @"411" . (,headers)
+
+return412 :: Return412 a n m tags
+return412 = return412WithHeaders []
+
+return412WithHeaders :: HTTP.ResponseHeaders -> Return412 a n m tags
+return412WithHeaders headers =
+  pure . S.unifyTaggedUnion @"412" . (,headers)
+
+return413 :: Return413 a n m tags
+return413 = return413WithHeaders []
+
+return413WithHeaders :: HTTP.ResponseHeaders -> Return413 a n m tags
+return413WithHeaders headers =
+  pure . S.unifyTaggedUnion @"413" . (,headers)
+
+return414 :: Return414 a n m tags
+return414 = return414WithHeaders []
+
+return414WithHeaders :: HTTP.ResponseHeaders -> Return414 a n m tags
+return414WithHeaders headers =
+  pure . S.unifyTaggedUnion @"414" . (,headers)
+
+return415 :: Return415 a n m tags
+return415 = return415WithHeaders []
+
+return415WithHeaders :: HTTP.ResponseHeaders -> Return415 a n m tags
+return415WithHeaders headers =
+  pure . S.unifyTaggedUnion @"415" . (,headers)
+
+return416 :: Return416 a n m tags
+return416 = return416WithHeaders []
+
+return416WithHeaders :: HTTP.ResponseHeaders -> Return416 a n m tags
+return416WithHeaders headers =
+  pure . S.unifyTaggedUnion @"416" . (,headers)
+
+return417 :: Return417 a n m tags
+return417 = return417WithHeaders []
+
+return417WithHeaders :: HTTP.ResponseHeaders -> Return417 a n m tags
+return417WithHeaders headers =
+  pure . S.unifyTaggedUnion @"417" . (,headers)
+
+return418 :: Return418 a n m tags
+return418 = return418WithHeaders []
+
+return418WithHeaders :: HTTP.ResponseHeaders -> Return418 a n m tags
+return418WithHeaders headers =
+  pure . S.unifyTaggedUnion @"418" . (,headers)
 
 return422 :: Return422 a n m tags
-return422 = pure . S.unifyTaggedUnion @"422" . (,[])
+return422 = return422WithHeaders []
+
+return422WithHeaders :: HTTP.ResponseHeaders -> Return422 a n m tags
+return422WithHeaders headers =
+  pure . S.unifyTaggedUnion @"422" . (,headers)
+
+return428 :: Return428 a n m tags
+return428 = return428WithHeaders []
+
+return428WithHeaders :: HTTP.ResponseHeaders -> Return428 a n m tags
+return428WithHeaders headers =
+  pure . S.unifyTaggedUnion @"428" . (,headers)
+
+return429 :: Return429 a n m tags
+return429 = return429WithHeaders []
+
+return429WithHeaders :: HTTP.ResponseHeaders -> Return429 a n m tags
+return429WithHeaders headers =
+  pure . S.unifyTaggedUnion @"429" . (,headers)
+
+return431 :: Return431 a n m tags
+return431 = return431WithHeaders []
+
+return431WithHeaders :: HTTP.ResponseHeaders -> Return431 a n m tags
+return431WithHeaders headers =
+  pure . S.unifyTaggedUnion @"431" . (,headers)
 
 return500 :: Return500 a n m tags
-return500 = pure . S.unifyTaggedUnion @"500" . (,[])
+return500 = return500WithHeaders []
+
+return500WithHeaders :: HTTP.ResponseHeaders -> Return500 a n m tags
+return500WithHeaders headers =
+  pure . S.unifyTaggedUnion @"500" . (,headers)
+
+return501 :: Return501 a n m tags
+return501 = return501WithHeaders []
+
+return501WithHeaders :: HTTP.ResponseHeaders -> Return501 a n m tags
+return501WithHeaders headers =
+  pure . S.unifyTaggedUnion @"501" . (,headers)
+
+return502 :: Return502 a n m tags
+return502 = return502WithHeaders []
+
+return502WithHeaders :: HTTP.ResponseHeaders -> Return502 a n m tags
+return502WithHeaders headers =
+  pure . S.unifyTaggedUnion @"502" . (,headers)
 
 return503 :: Return503 a n m tags
-return503 = pure . S.unifyTaggedUnion @"503" . (,[])
+return503 = return503WithHeaders []
+
+return503WithHeaders :: HTTP.ResponseHeaders -> Return503 a n m tags
+return503WithHeaders headers =
+  pure . S.unifyTaggedUnion @"503" . (,headers)
+
+return504 :: Return504 a n m tags
+return504 = return504WithHeaders []
+
+return504WithHeaders :: HTTP.ResponseHeaders -> Return504 a n m tags
+return504WithHeaders headers =
+  pure . S.unifyTaggedUnion @"504" . (,headers)
+
+return505 :: Return505 a n m tags
+return505 = return505WithHeaders []
+
+return505WithHeaders :: HTTP.ResponseHeaders -> Return505 a n m tags
+return505WithHeaders headers =
+  pure . S.unifyTaggedUnion @"505" . (,headers)
+
+return511 :: Return511 a n m tags
+return511 = return511WithHeaders []
+
+return511WithHeaders :: HTTP.ResponseHeaders -> Return511 a n m tags
+return511WithHeaders headers =
+  pure . S.unifyTaggedUnion @"511" . (,headers)

--- a/src/Orb/Response/StatusCodes.hs
+++ b/src/Orb/Response/StatusCodes.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -242,6 +240,8 @@ module Orb.Response.StatusCodes
   )
 where
 
+import Data.ByteString.Char8 qualified as BS8
+import Data.CaseInsensitive qualified as CI
 import Data.Map.Strict qualified as Map
 import Data.Proxy (Proxy (Proxy))
 import Fleece.Aeson.Encoder (encode)
@@ -255,6 +255,15 @@ import Orb.Response.Document (Document (..))
 import Orb.Response.Response (ResponseData (..), ResponseSchema (..), ResponseSchemasBuilder (..))
 import Orb.Response.Schemas (NoContent (..))
 
+{- | Adds a typed response for a given status code to the
+    'ResponseSchemasBuilder'.
+
+This function associates some type @a@ to a response code identified by the
+type-level @tag@. The response body will be the JSON encoding of the type as
+encoded by Fleece, and the @Content-Type@ will be set to @application/json@.
+
+@since 0.1.0
+-}
 addResponseSchema ::
   forall tag tags a.
   KnownHTTPStatus tag =>
@@ -274,7 +283,7 @@ addResponseSchema schema builder =
       ResponseData
         { responseDataStatus = status
         , responseDataBytes = encode schema value
-        , responseDataContentType = Just "application/json"
+        , responseDataContentType = Just $ BS8.pack "application/json"
         , responseDataExtraHeaders = headers
         }
   in
@@ -285,6 +294,17 @@ addResponseSchema schema builder =
           Map.insert status (ResponseSchema schema) (responseStatusMapBuilder builder)
       }
 
+{- | Adds a document response for a given status code to the
+'ResponseSchemasBuilder'.
+
+This function associates a 'Document' to a response code identified by the
+type-level @tag@. The response body will be the raw content from the provided
+'Document', the @Content-Type@ will be set to the document's MIME type, and the
+@Content-Disposition@ header is automatically generated using the document’s
+file name.
+
+@since 0.1.0
+-}
 addResponseDocument ::
   forall tag tags.
   KnownHTTPStatus tag =>
@@ -304,7 +324,9 @@ addResponseDocument builder =
         , responseDataBytes = documentContent document
         , responseDataContentType = Just $ documentType document
         , responseDataExtraHeaders =
-            ("Content-Disposition", "attachment;filename=" <> documentFileName document)
+            ( CI.mk $ BS8.pack "Content-Disposition"
+            , BS8.pack "attachment;filename=" <> documentFileName document
+            )
               : headers
         }
   in
@@ -315,6 +337,14 @@ addResponseDocument builder =
           Map.insert status ResponseDocument (responseStatusMapBuilder builder)
       }
 
+{- | Associates a /no-content/ type response with a given status code in the
+'ResponseSchemasBuilder'.
+
+When a no-content response is constructed this way, the response body will be
+empty, and the @Content-Type@ header will not be set.
+
+@since 0.1.0
+-}
 addNoResponseSchema ::
   forall tag tags.
   KnownHTTPStatus tag =>
@@ -344,630 +374,2540 @@ addNoResponseSchema builder =
           Map.insert status NoResponseSchema (responseStatusMapBuilder builder)
       }
 
+{- | A type class that links a type-level HTTP status code @tag@ to its
+corresponding 'HTTP.Status'.
+
+This class provides the 'httpStatusVal' method, which returns the runtime
+status value for a given @tag@ by mapping a type-level string (e.g., @\"404\"@)
+to a standard status code (e.g., 'HTTP.status404').
+
+When you create instances of 'KnownHTTPStatus', you enable automatic
+recognition of that tag as a valid HTTP status in the various response-building
+functions throughout this module.
+
+@since 0.1.0
+-}
 class KnownHTTPStatus tag where
   httpStatusVal :: proxy tag -> HTTP.Status
 
+{- | A type synonym representing an HTTP 100 (Continue) response with no
+content.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response100
+   ]
+@
+
+@since 0.1.0
+-}
 type Response100 = "100" @= (NoContent, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 101 (Switching Protocols) response
+with no content.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response101
+   ]
+@
+
+@since 0.1.0
+-}
 type Response101 = "101" @= (NoContent, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 200 (OK) response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response200 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response200 a = "200" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 201 (Created) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response201 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response201 a = "201" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 202 (Accepted) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response202 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response202 a = "202" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 203 (Non-Authoritative Information)
+response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response203 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response203 a = "203" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 204 (No Content) response with no
+content.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response204
+   ]
+@
+
+@since 0.1.0
+-}
 type Response204 = "204" @= (NoContent, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 205 (Reset Content) response with no
+content.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response205
+   ]
+@
+
+@since 0.1.0
+-}
 type Response205 = "205" @= (NoContent, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 206 (Partial Content) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response206 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response206 a = "206" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 300 (Multiple Choices) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response300 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response300 a = "300" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 301 (Moved Permanently) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response301 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response301 a = "301" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 302 (Found) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response302 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response302 a = "302" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 303 (See Other) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response303 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response303 a = "303" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 304 (Not Modified) response with no
+content.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response304
+   ]
+@
+
+@since 0.1.0
+-}
 type Response304 = "304" @= (NoContent, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 305 (Use Proxy) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response305 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response305 a = "305" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 307 (Temporary Redirect) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response307 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response307 a = "307" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 308 (Permanent Redirect) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response308 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response308 a = "308" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 400 (Bad Request) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response400 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response400 a = "400" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 401 (Unauthorized) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response401 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response401 a = "401" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 402 (Payment Required) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response402 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response402 a = "402" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 403 (Forbidden) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response403 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response403 a = "403" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 404 (Not Found) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response404 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response404 a = "404" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 405 (Method Not Allowed) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response405 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response405 a = "405" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 406 (Not Acceptable) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response406 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response406 a = "406" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 407 (Proxy Authentication Required)
+response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response407 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response407 a = "407" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 408 (Request Timeout) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response408 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response408 a = "408" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 409 (Conflict) response with a typed
+body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response409 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response409 a = "409" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 410 (Gone) response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response410 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response410 a = "410" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 411 (Length Required) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response411 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response411 a = "411" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 412 (Precondition Failed) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response412 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response412 a = "412" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 413 (Payload Too Large) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response413 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response413 a = "413" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 414 (URI Too Long) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response414 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response414 a = "414" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 415 (Unsupported Media Type) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response415 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response415 a = "415" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 416 (Range Not Satisfiable) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response416 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response416 a = "416" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 417 (Expectation Failed) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response417 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response417 a = "417" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 418 (I'm a Teapot) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response418 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response418 a = "418" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 422 (Unprocessable Entity) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response422 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response422 a = "422" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 428 (Precondition Required) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response428 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response428 a = "428" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 429 (Too Many Requests) response with
+a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response429 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response429 a = "429" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 431 (Request Header Fields Too Large)
+response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response431 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response431 a = "431" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 500 (Internal Server Error) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response500 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response500 a = "500" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 501 (Not Implemented) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response501 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response501 a = "501" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 502 (Bad Gateway) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response502 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response502 a = "502" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 503 (Service Unavailable) response
+with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response503 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response503 a = "503" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 504 (Gateway Timeout) response with a
+typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response504 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response504 a = "504" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 505 (HTTP Version Not Supported)
+response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response505 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response505 a = "505" @= (a, HTTP.ResponseHeaders)
+
+{- | A type synonym representing an HTTP 511 (Network Authentication Required)
+response with a typed body.
+
+/Example usage/:
+
+@
+type ResponseCodes =
+  '[ Response511 MyType
+   ]
+@
+
+@since 0.1.0
+-}
 type Response511 a = "511" @= (a, HTTP.ResponseHeaders)
 
+{- | Appends an HTTP 100 (Continue) no-content response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema100
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema100 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response100 : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response100 : responseCodes)
 addResponseSchema100 =
   addNoResponseSchema @"100"
 
+{- | Appends an HTTP 101 (Switching Protocols) no-content response to the set
+of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema101
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema101 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response101 : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response101 : responseCodes)
 addResponseSchema101 =
   addNoResponseSchema @"101"
 
+{- | Appends an HTTP 200 (OK) typed response to the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema200 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema200 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response200 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response200 a : responseCodes)
 addResponseSchema200 =
   addResponseSchema @"200"
 
+{- | Appends an HTTP 200 (OK) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument200
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument200 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response200 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response200 Document : responseCodes)
 addResponseDocument200 =
   addResponseDocument @"200"
 
+{- | Appends an HTTP 201 (Created) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema201 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema201 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response201 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response201 a : responseCodes)
 addResponseSchema201 =
   addResponseSchema @"201"
 
+{- | Appends an HTTP 201 (Created) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument201
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument201 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response201 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response201 Document : responseCodes)
 addResponseDocument201 =
   addResponseDocument @"201"
 
+{- | Appends an HTTP 202 (Accepted) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema202 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema202 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response202 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response202 a : responseCodes)
 addResponseSchema202 =
   addResponseSchema @"202"
 
+{- | Appends an HTTP 202 (Accepted) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument202
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument202 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response202 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response202 Document : responseCodes)
 addResponseDocument202 =
   addResponseDocument @"202"
 
+{- | Appends an HTTP 203 (Non-Authoritative Information) typed response to the
+set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema203 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema203 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response203 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response203 a : responseCodes)
 addResponseSchema203 =
   addResponseSchema @"203"
 
+{- | Appends an HTTP 203 (Non-Authoritative Information) document response to
+the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument203
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument203 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response203 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response203 Document : responseCodes)
 addResponseDocument203 =
   addResponseDocument @"203"
 
+{- | Appends an HTTP 204 (No Content) no-content response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema204 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema204 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response204 : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response204 : responseCodes)
 addResponseSchema204 =
   addNoResponseSchema @"204"
 
+{- | Appends an HTTP 205 (Reset Content) no-content response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema205
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema205 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response205 : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response205 : responseCodes)
 addResponseSchema205 =
   addNoResponseSchema @"205"
 
+{- | Appends an HTTP 206 (Partial Content) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema206 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema206 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response206 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response206 a : responseCodes)
 addResponseSchema206 =
   addResponseSchema @"206"
 
+{- | Appends an HTTP 206 (Partial Content) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument206
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument206 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response206 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response206 Document : responseCodes)
 addResponseDocument206 =
   addResponseDocument @"206"
 
+{- | Appends an HTTP 300 (Multiple Choices) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema300 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema300 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response300 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response300 a : responseCodes)
 addResponseSchema300 =
   addResponseSchema @"300"
 
+{- | Appends an HTTP 300 (Multiple Choices) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument300
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument300 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response300 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response300 Document : responseCodes)
 addResponseDocument300 =
   addResponseDocument @"300"
 
+{- | Appends an HTTP 301 (Moved Permanently) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema301 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema301 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response301 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response301 a : responseCodes)
 addResponseSchema301 =
   addResponseSchema @"301"
 
+{- | Appends an HTTP 301 (Moved Permanently) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument301
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument301 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response301 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response301 Document : responseCodes)
 addResponseDocument301 =
   addResponseDocument @"301"
 
+{- | Appends an HTTP 302 (Found) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema302 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema302 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response302 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response302 a : responseCodes)
 addResponseSchema302 =
   addResponseSchema @"302"
 
+{- | Appends an HTTP 302 (Found) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument302
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument302 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response302 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response302 Document : responseCodes)
 addResponseDocument302 =
   addResponseDocument @"302"
 
+{- | Appends an HTTP 303 (See Other) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema303 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema303 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response303 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response303 a : responseCodes)
 addResponseSchema303 =
   addResponseSchema @"303"
 
+{- | Appends an HTTP 303 (See Other) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument303
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument303 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response303 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response303 Document : responseCodes)
 addResponseDocument303 =
   addResponseDocument @"303"
 
+{- | Appends an HTTP 304 (Not Modified) no-content response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema304 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema304 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response304 : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response304 : responseCodes)
 addResponseSchema304 =
   addNoResponseSchema @"304"
 
+{- | Appends an HTTP 305 (Use Proxy) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema305 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema305 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response305 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response305 a : responseCodes)
 addResponseSchema305 =
   addResponseSchema @"305"
 
+{- | Appends an HTTP 305 (Use Proxy) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument305
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument305 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response305 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response305 Document : responseCodes)
 addResponseDocument305 =
   addResponseDocument @"305"
 
+{- | Appends an HTTP 307 (Temporary Redirect) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema307 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema307 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response307 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response307 a : responseCodes)
 addResponseSchema307 =
   addResponseSchema @"307"
 
+{- | Appends an HTTP 307 (Temporary Redirect) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument307
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument307 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response307 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response307 Document : responseCodes)
 addResponseDocument307 =
   addResponseDocument @"307"
 
+{- | Appends an HTTP 308 (Permanent Redirect) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema308 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema308 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response308 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response308 a : responseCodes)
 addResponseSchema308 =
   addResponseSchema @"308"
 
+{- | Appends an HTTP 308 (Permanent Redirect) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument308
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument308 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response308 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response308 Document : responseCodes)
 addResponseDocument308 =
   addResponseDocument @"308"
 
+{- | Appends an HTTP 400 (Bad Request) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema400 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema400 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response400 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response400 a : responseCodes)
 addResponseSchema400 =
   addResponseSchema @"400"
 
+{- | Appends an HTTP 400 (Bad Request) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument400
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument400 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response400 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response400 Document : responseCodes)
 addResponseDocument400 =
   addResponseDocument @"400"
 
+{- | Appends an HTTP 401 (Unauthorized) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema401 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema401 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response401 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response401 a : responseCodes)
 addResponseSchema401 =
   addResponseSchema @"401"
 
+{- | Appends an HTTP 401 (Unauthorized) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument401
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument401 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response401 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response401 Document : responseCodes)
 addResponseDocument401 =
   addResponseDocument @"401"
 
+{- | Appends an HTTP 402 (Payment Required) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema402 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema402 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response402 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response402 a : responseCodes)
 addResponseSchema402 =
   addResponseSchema @"402"
 
+{- | Appends an HTTP 402 (Payment Required) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument402
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument402 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response402 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response402 Document : responseCodes)
 addResponseDocument402 =
   addResponseDocument @"402"
 
+{- | Appends an HTTP 403 (Forbidden) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema403 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema403 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response403 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response403 a : responseCodes)
 addResponseSchema403 =
   addResponseSchema @"403"
 
+{- | Appends an HTTP 403 (Forbidden) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument403
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument403 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response403 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response403 Document : responseCodes)
 addResponseDocument403 =
   addResponseDocument @"403"
 
+{- | Appends an HTTP 404 (Not Found) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema404 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema404 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response404 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response404 a : responseCodes)
 addResponseSchema404 =
   addResponseSchema @"404"
 
+{- | Appends an HTTP 404 (Not Found) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument404
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument404 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response404 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response404 Document : responseCodes)
 addResponseDocument404 =
   addResponseDocument @"404"
 
+{- | Appends an HTTP 405 (Method Not Allowed) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema405 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema405 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response405 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response405 a : responseCodes)
 addResponseSchema405 =
   addResponseSchema @"405"
 
+{- | Appends an HTTP 405 (Method Not Allowed) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument405
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument405 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response405 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response405 Document : responseCodes)
 addResponseDocument405 =
   addResponseDocument @"405"
 
+{- | Appends an HTTP 406 (Not Acceptable) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema406 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema406 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response406 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response406 a : responseCodes)
 addResponseSchema406 =
   addResponseSchema @"406"
 
+{- | Appends an HTTP 406 (Not Acceptable) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument406
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument406 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response406 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response406 Document : responseCodes)
 addResponseDocument406 =
   addResponseDocument @"406"
 
+{- | Appends an HTTP 407 (Proxy Authentication Required) typed response to the
+set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema407 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema407 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response407 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response407 a : responseCodes)
 addResponseSchema407 =
   addResponseSchema @"407"
 
+{- | Appends an HTTP 407 (Proxy Authentication Required) document response to
+the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument407
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument407 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response407 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response407 Document : responseCodes)
 addResponseDocument407 =
   addResponseDocument @"407"
 
+{- | Appends an HTTP 408 (Request Timeout) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema408 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema408 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response408 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response408 a : responseCodes)
 addResponseSchema408 =
   addResponseSchema @"408"
 
+{- | Appends an HTTP 408 (Request Timeout) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument408
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument408 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response408 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response408 Document : responseCodes)
 addResponseDocument408 =
   addResponseDocument @"408"
 
+{- | Appends an HTTP 409 (Conflict) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema409 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema409 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response409 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response409 a : responseCodes)
 addResponseSchema409 =
   addResponseSchema @"409"
 
+{- | Appends an HTTP 409 (Conflict) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument409
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument409 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response409 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response409 Document : responseCodes)
 addResponseDocument409 =
   addResponseDocument @"409"
 
+{- | Appends an HTTP 410 (Gone) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema410 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema410 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response410 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response410 a : responseCodes)
 addResponseSchema410 =
   addResponseSchema @"410"
 
+{- | Appends an HTTP 410 (Gone) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument410
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument410 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response410 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response410 Document : responseCodes)
 addResponseDocument410 =
   addResponseDocument @"410"
 
+{- | Appends an HTTP 411 (Length Required) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema411 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema411 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response411 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response411 a : responseCodes)
 addResponseSchema411 =
   addResponseSchema @"411"
 
+{- | Appends an HTTP 411 (Length Required) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument411
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument411 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response411 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response411 Document : responseCodes)
 addResponseDocument411 =
   addResponseDocument @"411"
 
+{- | Appends an HTTP 412 (Precondition Failed) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema412 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema412 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response412 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response412 a : responseCodes)
 addResponseSchema412 =
   addResponseSchema @"412"
 
+{- | Appends an HTTP 412 (Precondition Failed) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument412
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument412 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response412 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response412 Document : responseCodes)
 addResponseDocument412 =
   addResponseDocument @"412"
 
+{- | Appends an HTTP 413 (Payload Too Large) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema413 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema413 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response413 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response413 a : responseCodes)
 addResponseSchema413 =
   addResponseSchema @"413"
 
+{- | Appends an HTTP 413 (Payload Too Large) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument413
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument413 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response413 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response413 Document : responseCodes)
 addResponseDocument413 =
   addResponseDocument @"413"
 
+{- | Appends an HTTP 414 (URI Too Long) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema414 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema414 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response414 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response414 a : responseCodes)
 addResponseSchema414 =
   addResponseSchema @"414"
 
+{- | Appends an HTTP 414 (URI Too Long) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument414
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument414 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response414 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response414 Document : responseCodes)
 addResponseDocument414 =
   addResponseDocument @"414"
 
+{- | Appends an HTTP 415 (Unsupported Media Type) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema415 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema415 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response415 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response415 a : responseCodes)
 addResponseSchema415 =
   addResponseSchema @"415"
 
+{- | Appends an HTTP 415 (Unsupported Media Type) document response to the set
+of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument415
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument415 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response415 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response415 Document : responseCodes)
 addResponseDocument415 =
   addResponseDocument @"415"
 
+{- | Appends an HTTP 416 (Range Not Satisfiable) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema416 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema416 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response416 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response416 a : responseCodes)
 addResponseSchema416 =
   addResponseSchema @"416"
 
+{- | Appends an HTTP 416 (Range Not Satisfiable) document response to the set
+of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument416
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument416 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response416 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response416 Document : responseCodes)
 addResponseDocument416 =
   addResponseDocument @"416"
 
+{- | Appends an HTTP 417 (Expectation Failed) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema417 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema417 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response417 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response417 a : responseCodes)
 addResponseSchema417 =
   addResponseSchema @"417"
 
+{- | Appends an HTTP 417 (Expectation Failed) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument417
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument417 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response417 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response417 Document : responseCodes)
 addResponseDocument417 =
   addResponseDocument @"417"
 
+{- | Appends an HTTP 418 (I'm a Teapot) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema418 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema418 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response418 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response418 a : responseCodes)
 addResponseSchema418 =
   addResponseSchema @"418"
 
+{- | Appends an HTTP 418 (I'm a Teapot) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument418
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument418 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response418 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response418 Document : responseCodes)
 addResponseDocument418 =
   addResponseDocument @"418"
 
+{- | Appends an HTTP 422 (Unprocessable Entity) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema422 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema422 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response422 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response422 a : responseCodes)
 addResponseSchema422 =
   addResponseSchema @"422"
 
+{- | Appends an HTTP 422 (Unprocessable Entity) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument422
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument422 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response422 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response422 Document : responseCodes)
 addResponseDocument422 =
   addResponseDocument @"422"
 
+{- | Appends an HTTP 428 (Precondition Required) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema428 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema428 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response428 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response428 a : responseCodes)
 addResponseSchema428 =
   addResponseSchema @"428"
 
+{- | Appends an HTTP 428 (Precondition Required) document response to the set
+of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument428
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument428 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response428 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response428 Document : responseCodes)
 addResponseDocument428 =
   addResponseDocument @"428"
 
+{- | Appends an HTTP 429 (Too Many Requests) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema429 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema429 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response429 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response429 a : responseCodes)
 addResponseSchema429 =
   addResponseSchema @"429"
 
+{- | Appends an HTTP 429 (Too Many Requests) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument429
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument429 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response429 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response429 Document : responseCodes)
 addResponseDocument429 =
   addResponseDocument @"429"
 
+{- | Appends an HTTP 431 (Request Header Fields Too Large) typed response to
+the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema431 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema431 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response431 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response431 a : responseCodes)
 addResponseSchema431 =
   addResponseSchema @"431"
 
+{- | Appends an HTTP 431 (Request Header Fields Too Large) document response to
+the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument431
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument431 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response431 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response431 Document : responseCodes)
 addResponseDocument431 =
   addResponseDocument @"431"
 
+{- | Appends an HTTP 500 (Internal Server Error) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema500 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema500 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response500 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response500 a : responseCodes)
 addResponseSchema500 =
   addResponseSchema @"500"
 
+{- | Appends an HTTP 500 (Internal Server Error) document response to the set
+of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument500
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument500 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response500 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response500 Document : responseCodes)
 addResponseDocument500 =
   addResponseDocument @"500"
 
+{- | Appends an HTTP 501 (Not Implemented) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema501 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema501 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response501 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response501 a : responseCodes)
 addResponseSchema501 =
   addResponseSchema @"501"
 
+{- | Appends an HTTP 501 (Not Implemented) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument501
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument501 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response501 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response501 Document : responseCodes)
 addResponseDocument501 =
   addResponseDocument @"501"
 
+{- | Appends an HTTP 502 (Bad Gateway) typed response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema502 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema502 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response502 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response502 a : responseCodes)
 addResponseSchema502 =
   addResponseSchema @"502"
 
+{- | Appends an HTTP 502 (Bad Gateway) document response to the set of possible
+responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument502
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument502 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response502 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response502 Document : responseCodes)
 addResponseDocument502 =
   addResponseDocument @"502"
 
+{- | Appends an HTTP 503 (Service Unavailable) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema503 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema503 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response503 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response503 a : responseCodes)
 addResponseSchema503 =
   addResponseSchema @"503"
 
+{- | Appends an HTTP 503 (Service Unavailable) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument503
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument503 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response503 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response503 Document : responseCodes)
 addResponseDocument503 =
   addResponseDocument @"503"
 
+{- | Appends an HTTP 504 (Gateway Timeout) typed response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema504 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema504 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response504 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response504 a : responseCodes)
 addResponseSchema504 =
   addResponseSchema @"504"
 
+{- | Appends an HTTP 504 (Gateway Timeout) document response to the set of
+possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument504
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument504 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response504 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response504 Document : responseCodes)
 addResponseDocument504 =
   addResponseDocument @"504"
 
+{- | Appends an HTTP 505 (HTTP Version Not Supported) typed response to the set
+of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema505 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema505 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response505 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response505 a : responseCodes)
 addResponseSchema505 =
   addResponseSchema @"505"
 
+{- | Appends an HTTP 505 (HTTP Version Not Supported) document response to the
+set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument505
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument505 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response505 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response505 Document : responseCodes)
 addResponseDocument505 =
   addResponseDocument @"505"
 
+{- | Appends an HTTP 511 (Network Authentication Required) typed response to
+the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseSchema511 myTypeSchema
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseSchema511 ::
+  forall a responseCodes.
   (forall schema. FC.Fleece schema => schema a) ->
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response511 a : tags)
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response511 a : responseCodes)
 addResponseSchema511 =
   addResponseSchema @"511"
 
+{- | Appends an HTTP 511 (Network Authentication Required) document response to
+the set of possible responses.
+
+/Example usage/:
+
+@
+responseSchemas
+  . addResponseDocument511
+  $ noResponseSchemas
+@
+
+@since 0.1.0
+-}
 addResponseDocument511 ::
-  ResponseSchemasBuilder tags ->
-  ResponseSchemasBuilder (Response511 Document : tags)
+  forall responseCodes.
+  ResponseSchemasBuilder responseCodes ->
+  ResponseSchemasBuilder (Response511 Document : responseCodes)
 addResponseDocument511 =
   addResponseDocument @"511"
 
@@ -1112,389 +3052,798 @@ instance KnownHTTPStatus "505" where
 instance KnownHTTPStatus "511" where
   httpStatusVal _ = HTTP.status511
 
-type ReturnType a n m tags code =
-  ( (a, HTTP.ResponseHeaders) ~ S.TagType code tags
-  , n ~ S.TagIndex code tags
-  , (a, HTTP.ResponseHeaders) ~ S.TypeAtIndex n (S.TaggedTypes tags)
-  , KnownNat n
+{- | A type synonym that encodes how a handler function can produce a typed
+response for a given status code in a monadic context.
+
+The key idea is that @returnType@ represents the actual response body type
+(e.g., a JSON-serializable record or a custom document), while the underlying
+constraint ensures it corresponds correctly to a status @code@ within the
+'Shrubbery' tagged union of responses (parameterized by @responseCodes@). It
+also requires @m@ to have an instance of an 'Applicative'.
+
+This type alias is primarily used to define more specific response functions
+such as 'Return200' or 'Return404', which fix the @code@ to particular HTTP
+status codes. Those synonyms, in turn, give you a convenient way to ensure that
+any function returning them lines up exactly with the response codes in the
+'ResponseSchemasBuilder'.
+
+@since 0.1.0
+-}
+type ReturnType returnType index m responseCodes code =
+  ( (returnType, HTTP.ResponseHeaders) ~ S.TagType code responseCodes
+  , index ~ S.TagIndex code responseCodes
+  , (returnType, HTTP.ResponseHeaders) ~ S.TypeAtIndex index (S.TaggedTypes responseCodes)
+  , KnownNat index
   , Applicative m
   ) =>
-  a ->
-  m (S.TaggedUnion tags)
+  returnType ->
+  m (S.TaggedUnion responseCodes)
 
-type Return100 n m tags = ReturnType NoContent n m tags "100"
-type Return101 n m tags = ReturnType NoContent n m tags "101"
-type Return200 a n m tags = ReturnType a n m tags "200"
-type Return201 a n m tags = ReturnType a n m tags "201"
-type Return202 a n m tags = ReturnType a n m tags "202"
-type Return203 a n m tags = ReturnType a n m tags "203"
-type Return204 n m tags = ReturnType NoContent n m tags "204"
-type Return205 n m tags = ReturnType NoContent n m tags "205"
-type Return206 a n m tags = ReturnType a n m tags "206"
-type Return300 a n m tags = ReturnType a n m tags "300"
-type Return301 a n m tags = ReturnType a n m tags "301"
-type Return302 a n m tags = ReturnType a n m tags "302"
-type Return303 a n m tags = ReturnType a n m tags "303"
-type Return304 n m tags = ReturnType NoContent n m tags "304"
-type Return305 a n m tags = ReturnType a n m tags "305"
-type Return307 a n m tags = ReturnType a n m tags "307"
-type Return308 a n m tags = ReturnType a n m tags "308"
-type Return400 a n m tags = ReturnType a n m tags "400"
-type Return401 a n m tags = ReturnType a n m tags "401"
-type Return402 a n m tags = ReturnType a n m tags "402"
-type Return403 a n m tags = ReturnType a n m tags "403"
-type Return404 a n m tags = ReturnType a n m tags "404"
-type Return405 a n m tags = ReturnType a n m tags "405"
-type Return406 a n m tags = ReturnType a n m tags "406"
-type Return407 a n m tags = ReturnType a n m tags "407"
-type Return408 a n m tags = ReturnType a n m tags "408"
-type Return409 a n m tags = ReturnType a n m tags "409"
-type Return410 a n m tags = ReturnType a n m tags "410"
-type Return411 a n m tags = ReturnType a n m tags "411"
-type Return412 a n m tags = ReturnType a n m tags "412"
-type Return413 a n m tags = ReturnType a n m tags "413"
-type Return414 a n m tags = ReturnType a n m tags "414"
-type Return415 a n m tags = ReturnType a n m tags "415"
-type Return416 a n m tags = ReturnType a n m tags "416"
-type Return417 a n m tags = ReturnType a n m tags "417"
-type Return418 a n m tags = ReturnType a n m tags "418"
-type Return422 a n m tags = ReturnType a n m tags "422"
-type Return428 a n m tags = ReturnType a n m tags "428"
-type Return429 a n m tags = ReturnType a n m tags "429"
-type Return431 a n m tags = ReturnType a n m tags "431"
-type Return500 a n m tags = ReturnType a n m tags "500"
-type Return501 a n m tags = ReturnType a n m tags "501"
-type Return502 a n m tags = ReturnType a n m tags "502"
-type Return503 a n m tags = ReturnType a n m tags "503"
-type Return504 a n m tags = ReturnType a n m tags "504"
-type Return505 a n m tags = ReturnType a n m tags "505"
-type Return511 a n m tags = ReturnType a n m tags "511"
+{- | A type synonym representing a monadic action returning an HTTP 100
+(Continue) no-content response.
+-}
+type Return100 index m responseCodes =
+  ReturnType NoContent index m responseCodes "100"
 
-return100 :: Return100 n m tags
+{- | A type synonym representing a monadic action returning an HTTP 101
+(Switching Protocols) no-content response.
+-}
+type Return101 index m responseCodes =
+  ReturnType NoContent index m responseCodes "101"
+
+{- | A type synonym representing a monadic action returning an HTTP 200 (OK)
+typed response.
+-}
+type Return200 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "200"
+
+{- | A type synonym representing a monadic action returning an HTTP 201
+(Created) typed response.
+-}
+type Return201 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "201"
+
+{- | A type synonym representing a monadic action returning an HTTP 202
+(Accepted) typed response.
+-}
+type Return202 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "202"
+
+{- | A type synonym representing a monadic action returning an HTTP 203
+(Non-Authoritative Information) typed response.
+-}
+type Return203 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "203"
+
+{- | A type synonym representing a monadic action returning an HTTP 204 (No
+Content) no-content response.
+-}
+type Return204 index m responseCodes =
+  ReturnType NoContent index m responseCodes "204"
+
+{- | A type synonym representing a monadic action returning an HTTP 205 (Reset
+Content) no-content response.
+-}
+type Return205 index m responseCodes =
+  ReturnType NoContent index m responseCodes "205"
+
+{- | A type synonym representing a monadic action returning an HTTP 206
+(Partial Content) typed response.
+-}
+type Return206 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "206"
+
+{- | A type synonym representing a monadic action returning an HTTP 300
+(Multiple Choices) typed response.
+-}
+type Return300 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "300"
+
+{- | A type synonym representing a monadic action returning an HTTP 301 (Moved
+Permanently) typed response.
+-}
+type Return301 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "301"
+
+{- | A type synonym representing a monadic action returning an HTTP 302 (Found)
+typed response.
+-}
+type Return302 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "302"
+
+{- | A type synonym representing a monadic action returning an HTTP 303 (See
+Other) typed response.
+-}
+type Return303 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "303"
+
+{- | A type synonym representing a monadic action returning an HTTP 304 (Not
+Modified) no-content response.
+-}
+type Return304 index m responseCodes =
+  ReturnType NoContent index m responseCodes "304"
+
+{- | A type synonym representing a monadic action returning an HTTP 305 (Use
+Proxy) typed response.
+-}
+type Return305 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "305"
+
+{- | A type synonym representing a monadic action returning an HTTP 307
+(Temporary Redirect) typed response.
+-}
+type Return307 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "307"
+
+{- | A type synonym representing a monadic action returning an HTTP 308
+(Permanent Redirect) typed response.
+-}
+type Return308 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "308"
+
+{- | A type synonym representing a monadic action returning an HTTP 400 (Bad
+Request) typed response.
+-}
+type Return400 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "400"
+
+{- | A type synonym representing a monadic action returning an HTTP 401
+(Unauthorized) typed response.
+-}
+type Return401 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "401"
+
+{- | A type synonym representing a monadic action returning an HTTP 402
+(Payment Required) typed response.
+-}
+type Return402 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "402"
+
+{- | A type synonym representing a monadic action returning an HTTP 403
+(Forbidden) typed response.
+-}
+type Return403 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "403"
+
+{- | A type synonym representing a monadic action returning an HTTP 404 (Not
+Found) typed response.
+-}
+type Return404 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "404"
+
+{- | A type synonym representing a monadic action returning an HTTP 405 (Method
+Not Allowed) typed response.
+-}
+type Return405 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "405"
+
+{- | A type synonym representing a monadic action returning an HTTP 406 (Not
+Acceptable) typed response.
+-}
+type Return406 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "406"
+
+{- | A type synonym representing a monadic action returning an HTTP 407 (Proxy
+Authentication Required) typed response.
+-}
+type Return407 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "407"
+
+{- | A type synonym representing a monadic action returning an HTTP 408
+(Request Timeout) typed response.
+-}
+type Return408 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "408"
+
+{- | A type synonym representing a monadic action returning an HTTP 409
+(Conflict) typed response.
+-}
+type Return409 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "409"
+
+{- | A type synonym representing a monadic action returning an HTTP 410 (Gone)
+typed response.
+-}
+type Return410 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "410"
+
+{- | A type synonym representing a monadic action returning an HTTP 411 (Length
+Required) typed response.
+-}
+type Return411 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "411"
+
+{- | A type synonym representing a monadic action returning an HTTP 412
+(Precondition Failed) typed response.
+-}
+type Return412 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "412"
+
+{- | A type synonym representing a monadic action returning an HTTP 413
+(Payload Too Large) typed response.
+-}
+type Return413 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "413"
+
+{- | A type synonym representing a monadic action returning an HTTP 414 (URI
+Too Long) typed response.
+-}
+type Return414 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "414"
+
+{- | A type synonym representing a monadic action returning an HTTP 415
+(Unsupported Media Type) typed response.
+-}
+type Return415 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "415"
+
+{- | A type synonym representing a monadic action returning an HTTP 416 (Range
+Not Satisfiable) typed response.
+-}
+type Return416 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "416"
+
+{- | A type synonym representing a monadic action returning an HTTP 417
+(Expectation Failed) typed response.
+-}
+type Return417 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "417"
+
+{- | A type synonym representing a monadic action returning an HTTP 418 (I'm a
+Teapot) typed response.
+-}
+type Return418 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "418"
+
+{- | A type synonym representing a monadic action returning an HTTP 422
+(Unprocessable Entity) typed response.
+-}
+type Return422 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "422"
+
+{- | A type synonym representing a monadic action returning an HTTP 428
+(Precondition Required) typed response.
+-}
+type Return428 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "428"
+
+{- | A type synonym representing a monadic action returning an HTTP 429 (Too
+Many Requests) typed response.
+-}
+type Return429 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "429"
+
+{- | A type synonym representing a monadic action returning an HTTP 431
+(Request Header Fields Too Large) typed response.
+-}
+type Return431 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "431"
+
+{- | A type synonym representing a monadic action returning an HTTP 500
+(Internal Server Error) typed response.
+-}
+type Return500 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "500"
+
+{- | A type synonym representing a monadic action returning an HTTP 501 (Not
+Implemented) typed response.
+-}
+type Return501 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "501"
+
+{- | A type synonym representing a monadic action returning an HTTP 502 (Bad
+Gateway) typed response.
+-}
+type Return502 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "502"
+
+{- | A type synonym representing a monadic action returning an HTTP 503
+(Service Unavailable) typed response.
+-}
+type Return503 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "503"
+
+{- | A type synonym representing a monadic action returning an HTTP 504
+(Gateway Timeout) typed response.
+-}
+type Return504 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "504"
+
+{- | A type synonym representing a monadic action returning an HTTP 505 (HTTP
+Version Not Supported) typed response.
+-}
+type Return505 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "505"
+
+{- | A type synonym representing a monadic action returning an HTTP 511
+(Network Authentication Required) typed response.
+-}
+type Return511 returnType index m responseCodes =
+  ReturnType returnType index m responseCodes "511"
+
+-- | Returns an HTTP 100 (Continue) no-content response.
+return100 :: Return100 index m responseCodes
 return100 = return100WithHeaders []
 
-return100WithHeaders :: HTTP.ResponseHeaders -> Return100 n m tags
+{- | Returns an HTTP 100 (Continue) no-content response with additional
+headers.
+-}
+return100WithHeaders :: HTTP.ResponseHeaders -> Return100 index m responseCodes
 return100WithHeaders headers =
   pure . S.unifyTaggedUnion @"100" . (,headers)
 
-return101 :: Return101 n m tags
+-- | Returns an HTTP 101 (Switching Protocols) no-content response.
+return101 :: Return101 index m responseCodes
 return101 = return101WithHeaders []
 
-return101WithHeaders :: HTTP.ResponseHeaders -> Return101 n m tags
+{- | Returns an HTTP 101 (Switching Protocols) no-content response with
+additional headers.
+-}
+return101WithHeaders :: HTTP.ResponseHeaders -> Return101 index m responseCodes
 return101WithHeaders headers =
   pure . S.unifyTaggedUnion @"101" . (,headers)
 
-return200 :: Return200 a n m tags
+-- | Returns an HTTP 200 (OK) typed response.
+return200 :: Return200 returnType index m responseCodes
 return200 = return200WithHeaders []
 
-return200WithHeaders :: HTTP.ResponseHeaders -> Return200 a n m tags
+-- | Returns an HTTP 200 (OK) typed response with additional headers.
+return200WithHeaders :: HTTP.ResponseHeaders -> Return200 returnType index m responseCodes
 return200WithHeaders headers =
   pure . S.unifyTaggedUnion @"200" . (,headers)
 
-return201 :: Return201 a n m tags
+-- | Returns an HTTP 201 (Created) typed response.
+return201 :: Return201 returnType index m responseCodes
 return201 = return201WithHeaders []
 
-return201WithHeaders :: HTTP.ResponseHeaders -> Return201 a n m tags
+-- | Returns an HTTP 201 (Created) typed response with additional headers.
+return201WithHeaders :: HTTP.ResponseHeaders -> Return201 returnType index m responseCodes
 return201WithHeaders headers =
   pure . S.unifyTaggedUnion @"201" . (,headers)
 
-return202 :: Return202 a n m tags
+-- | Returns an HTTP 202 (Accepted) typed response.
+return202 :: Return202 returnType index m responseCodes
 return202 = return202WithHeaders []
 
-return202WithHeaders :: HTTP.ResponseHeaders -> Return202 a n m tags
+-- | Returns an HTTP 202 (Accepted) typed response with additional headers.
+return202WithHeaders :: HTTP.ResponseHeaders -> Return202 returnType index m responseCodes
 return202WithHeaders headers =
   pure . S.unifyTaggedUnion @"202" . (,headers)
 
-return203 :: Return203 a n m tags
+-- | Returns an HTTP 203 (Non-Authoritative Information) typed response.
+return203 :: Return203 returnType index m responseCodes
 return203 = return203WithHeaders []
 
-return203WithHeaders :: HTTP.ResponseHeaders -> Return203 a n m tags
+{- | Returns an HTTP 203 (Non-Authoritative Information) typed response with
+additional headers.
+-}
+return203WithHeaders :: HTTP.ResponseHeaders -> Return203 returnType index m responseCodes
 return203WithHeaders headers =
   pure . S.unifyTaggedUnion @"203" . (,headers)
 
-return204 :: Return204 n m tags
+-- | Returns an HTTP 204 (No Content) no-content response.
+return204 :: Return204 index m responseCodes
 return204 = return204WithHeaders []
 
-return204WithHeaders :: HTTP.ResponseHeaders -> Return204 n m tags
+{- | Returns an HTTP 204 (No Content) no-content response with additional
+headers.
+-}
+return204WithHeaders :: HTTP.ResponseHeaders -> Return204 index m responseCodes
 return204WithHeaders headers =
   pure . S.unifyTaggedUnion @"204" . (,headers)
 
-return205 :: Return205 n m tags
+-- | Returns an HTTP 205 (Reset Content) no-content response.
+return205 :: Return205 index m responseCodes
 return205 = return205WithHeaders []
 
-return205WithHeaders :: HTTP.ResponseHeaders -> Return205 n m tags
+{- | Returns an HTTP 205 (Reset Content) no-content response with additional
+headers.
+-}
+return205WithHeaders :: HTTP.ResponseHeaders -> Return205 index m responseCodes
 return205WithHeaders headers =
   pure . S.unifyTaggedUnion @"205" . (,headers)
 
-return206 :: Return206 a n m tags
+-- | Returns an HTTP 206 (Partial Content) typed response.
+return206 :: Return206 returnType index m responseCodes
 return206 = return206WithHeaders []
 
-return206WithHeaders :: HTTP.ResponseHeaders -> Return206 a n m tags
+{- | Returns an HTTP 206 (Partial Content) typed response with additional
+headers.
+-}
+return206WithHeaders :: HTTP.ResponseHeaders -> Return206 returnType index m responseCodes
 return206WithHeaders headers =
   pure . S.unifyTaggedUnion @"206" . (,headers)
 
-return300 :: Return300 a n m tags
+-- | Returns an HTTP 300 (Multiple Choices) typed response.
+return300 :: Return300 returnType index m responseCodes
 return300 = return300WithHeaders []
 
-return300WithHeaders :: HTTP.ResponseHeaders -> Return300 a n m tags
+{- | Returns an HTTP 300 (Multiple Choices) typed response with additional
+headers.
+-}
+return300WithHeaders :: HTTP.ResponseHeaders -> Return300 returnType index m responseCodes
 return300WithHeaders headers =
   pure . S.unifyTaggedUnion @"300" . (,headers)
 
-return301 :: Return301 a n m tags
+-- | Returns an HTTP 301 (Moved Permanently) typed response.
+return301 :: Return301 returnType index m responseCodes
 return301 = return301WithHeaders []
 
-return301WithHeaders :: HTTP.ResponseHeaders -> Return301 a n m tags
+{- | Returns an HTTP 301 (Moved Permanently) typed response with additional
+headers.
+-}
+return301WithHeaders :: HTTP.ResponseHeaders -> Return301 returnType index m responseCodes
 return301WithHeaders headers =
   pure . S.unifyTaggedUnion @"301" . (,headers)
 
-return302 :: Return302 a n m tags
+-- | Returns an HTTP 302 (Found) typed response.
+return302 :: Return302 returnType index m responseCodes
 return302 = return302WithHeaders []
 
-return302WithHeaders :: HTTP.ResponseHeaders -> Return302 a n m tags
+-- | Returns an HTTP 302 (Found) typed response with additional headers.
+return302WithHeaders :: HTTP.ResponseHeaders -> Return302 returnType index m responseCodes
 return302WithHeaders headers =
   pure . S.unifyTaggedUnion @"302" . (,headers)
 
-return303 :: Return303 a n m tags
+-- | Returns an HTTP 303 (See Other) typed response.
+return303 :: Return303 returnType index m responseCodes
 return303 = return303WithHeaders []
 
-return303WithHeaders :: HTTP.ResponseHeaders -> Return303 a n m tags
+-- | Returns an HTTP 303 (See Other) typed response with additional headers.
+return303WithHeaders :: HTTP.ResponseHeaders -> Return303 returnType index m responseCodes
 return303WithHeaders headers =
   pure . S.unifyTaggedUnion @"303" . (,headers)
 
-return304 :: Return304 n m tags
+-- | Returns an HTTP 304 (Not Modified) no-content response.
+return304 :: Return304 index m responseCodes
 return304 = return304WithHeaders []
 
-return304WithHeaders :: HTTP.ResponseHeaders -> Return304 n m tags
+{- | Returns an HTTP 304 (Not Modified) no-content response with additional
+headers.
+-}
+return304WithHeaders :: HTTP.ResponseHeaders -> Return304 index m responseCodes
 return304WithHeaders headers =
   pure . S.unifyTaggedUnion @"304" . (,headers)
 
-return305 :: Return305 a n m tags
+-- | Returns an HTTP 305 (Use Proxy) typed response.
+return305 :: Return305 returnType index m responseCodes
 return305 = return305WithHeaders []
 
-return305WithHeaders :: HTTP.ResponseHeaders -> Return305 a n m tags
+-- | Returns an HTTP 305 (Use Proxy) typed response with additional headers.
+return305WithHeaders :: HTTP.ResponseHeaders -> Return305 returnType index m responseCodes
 return305WithHeaders headers =
   pure . S.unifyTaggedUnion @"305" . (,headers)
 
-return307 :: Return307 a n m tags
+-- | Returns an HTTP 307 (Temporary Redirect) typed response.
+return307 :: Return307 returnType index m responseCodes
 return307 = return307WithHeaders []
 
-return307WithHeaders :: HTTP.ResponseHeaders -> Return307 a n m tags
+{- | Returns an HTTP 307 (Temporary Redirect) typed response with additional
+headers.
+-}
+return307WithHeaders :: HTTP.ResponseHeaders -> Return307 returnType index m responseCodes
 return307WithHeaders headers =
   pure . S.unifyTaggedUnion @"307" . (,headers)
 
-return308 :: Return308 a n m tags
+-- | Returns an HTTP 308 (Permanent Redirect) typed response.
+return308 :: Return308 returnType index m responseCodes
 return308 = return308WithHeaders []
 
-return308WithHeaders :: HTTP.ResponseHeaders -> Return308 a n m tags
+{- | Returns an HTTP 308 (Permanent Redirect) typed response with additional
+headers.
+-}
+return308WithHeaders :: HTTP.ResponseHeaders -> Return308 returnType index m responseCodes
 return308WithHeaders headers =
   pure . S.unifyTaggedUnion @"308" . (,headers)
 
-return400 :: Return400 a n m tags
+-- | Returns an HTTP 400 (Bad Request) typed response.
+return400 :: Return400 returnType index m responseCodes
 return400 = return400WithHeaders []
 
-return400WithHeaders :: HTTP.ResponseHeaders -> Return400 a n m tags
+-- | Returns an HTTP 400 (Bad Request) typed response with additional headers.
+return400WithHeaders :: HTTP.ResponseHeaders -> Return400 returnType index m responseCodes
 return400WithHeaders headers =
   pure . S.unifyTaggedUnion @"400" . (,headers)
 
-return401 :: Return401 a n m tags
+-- | Returns an HTTP 401 (Unauthorized) typed response.
+return401 :: Return401 returnType index m responseCodes
 return401 = return401WithHeaders []
 
-return401WithHeaders :: HTTP.ResponseHeaders -> Return401 a n m tags
+-- | Returns an HTTP 401 (Unauthorized) typed response with additional headers.
+return401WithHeaders :: HTTP.ResponseHeaders -> Return401 returnType index m responseCodes
 return401WithHeaders headers =
   pure . S.unifyTaggedUnion @"401" . (,headers)
 
-return402 :: Return402 a n m tags
+-- | Returns an HTTP 402 (Payment Required) typed response.
+return402 :: Return402 returnType index m responseCodes
 return402 = return402WithHeaders []
 
-return402WithHeaders :: HTTP.ResponseHeaders -> Return402 a n m tags
+{- | Returns an HTTP 402 (Payment Required) typed response with additional
+headers.
+-}
+return402WithHeaders :: HTTP.ResponseHeaders -> Return402 returnType index m responseCodes
 return402WithHeaders headers =
   pure . S.unifyTaggedUnion @"402" . (,headers)
 
-return403 :: Return403 a n m tags
+-- | Returns an HTTP 403 (Forbidden) typed response.
+return403 :: Return403 returnType index m responseCodes
 return403 = return403WithHeaders []
 
-return403WithHeaders :: HTTP.ResponseHeaders -> Return403 a n m tags
+-- | Returns an HTTP 403 (Forbidden) typed response with additional headers.
+return403WithHeaders :: HTTP.ResponseHeaders -> Return403 returnType index m responseCodes
 return403WithHeaders headers =
   pure . S.unifyTaggedUnion @"403" . (,headers)
 
-return404 :: Return404 a n m tags
+-- | Returns an HTTP 404 (Not Found) typed response.
+return404 :: Return404 returnType index m responseCodes
 return404 = return404WithHeaders []
 
-return404WithHeaders :: HTTP.ResponseHeaders -> Return404 a n m tags
+-- | Returns an HTTP 404 (Not Found) typed response with additional headers.
+return404WithHeaders :: HTTP.ResponseHeaders -> Return404 returnType index m responseCodes
 return404WithHeaders headers =
   pure . S.unifyTaggedUnion @"404" . (,headers)
 
-return405 :: Return405 a n m tags
+-- | Returns an HTTP 405 (Method Not Allowed) typed response.
+return405 :: Return405 returnType index m responseCodes
 return405 = return405WithHeaders []
 
-return405WithHeaders :: HTTP.ResponseHeaders -> Return405 a n m tags
+{- | Returns an HTTP 405 (Method Not Allowed) typed response with additional
+headers.
+-}
+return405WithHeaders :: HTTP.ResponseHeaders -> Return405 returnType index m responseCodes
 return405WithHeaders headers =
   pure . S.unifyTaggedUnion @"405" . (,headers)
 
-return406 :: Return406 a n m tags
+-- | Returns an HTTP 406 (Not Acceptable) typed response.
+return406 :: Return406 returnType index m responseCodes
 return406 = return406WithHeaders []
 
-return406WithHeaders :: HTTP.ResponseHeaders -> Return406 a n m tags
+{- | Returns an HTTP 406 (Not Acceptable) typed response with additional
+headers.
+-}
+return406WithHeaders :: HTTP.ResponseHeaders -> Return406 returnType index m responseCodes
 return406WithHeaders headers =
   pure . S.unifyTaggedUnion @"406" . (,headers)
 
-return407 :: Return407 a n m tags
+-- | Returns an HTTP 407 (Proxy Authentication Required) typed response.
+return407 :: Return407 returnType index m responseCodes
 return407 = return407WithHeaders []
 
-return407WithHeaders :: HTTP.ResponseHeaders -> Return407 a n m tags
+{- | Returns an HTTP 407 (Proxy Authentication Required) typed response with
+additional headers.
+-}
+return407WithHeaders :: HTTP.ResponseHeaders -> Return407 returnType index m responseCodes
 return407WithHeaders headers =
   pure . S.unifyTaggedUnion @"407" . (,headers)
 
-return408 :: Return408 a n m tags
+-- | Returns an HTTP 408 (Request Timeout) typed response.
+return408 :: Return408 returnType index m responseCodes
 return408 = return408WithHeaders []
 
-return408WithHeaders :: HTTP.ResponseHeaders -> Return408 a n m tags
+{- | Returns an HTTP 408 (Request Timeout) typed response with additional
+headers.
+-}
+return408WithHeaders :: HTTP.ResponseHeaders -> Return408 returnType index m responseCodes
 return408WithHeaders headers =
   pure . S.unifyTaggedUnion @"408" . (,headers)
 
-return409 :: Return409 a n m tags
+-- | Returns an HTTP 409 (Conflict) typed response.
+return409 :: Return409 returnType index m responseCodes
 return409 = return409WithHeaders []
 
-return409WithHeaders :: HTTP.ResponseHeaders -> Return409 a n m tags
+-- | Returns an HTTP 409 (Conflict) typed response with additional headers.
+return409WithHeaders :: HTTP.ResponseHeaders -> Return409 returnType index m responseCodes
 return409WithHeaders headers =
   pure . S.unifyTaggedUnion @"409" . (,headers)
 
-return410 :: Return410 a n m tags
+-- | Returns an HTTP 410 (Gone) typed response.
+return410 :: Return410 returnType index m responseCodes
 return410 = return410WithHeaders []
 
-return410WithHeaders :: HTTP.ResponseHeaders -> Return410 a n m tags
+-- | Returns an HTTP 410 (Gone) typed response with additional headers.
+return410WithHeaders :: HTTP.ResponseHeaders -> Return410 returnType index m responseCodes
 return410WithHeaders headers =
   pure . S.unifyTaggedUnion @"410" . (,headers)
 
-return411 :: Return411 a n m tags
+-- | Returns an HTTP 411 (Length Required) typed response.
+return411 :: Return411 returnType index m responseCodes
 return411 = return411WithHeaders []
 
-return411WithHeaders :: HTTP.ResponseHeaders -> Return411 a n m tags
+{- | Returns an HTTP 411 (Length Required) typed response with additional
+headers.
+-}
+return411WithHeaders :: HTTP.ResponseHeaders -> Return411 returnType index m responseCodes
 return411WithHeaders headers =
   pure . S.unifyTaggedUnion @"411" . (,headers)
 
-return412 :: Return412 a n m tags
+-- | Returns an HTTP 412 (Precondition Failed) typed response.
+return412 :: Return412 returnType index m responseCodes
 return412 = return412WithHeaders []
 
-return412WithHeaders :: HTTP.ResponseHeaders -> Return412 a n m tags
+{- | Returns an HTTP 412 (Precondition Failed) typed response with additional
+headers.
+-}
+return412WithHeaders :: HTTP.ResponseHeaders -> Return412 returnType index m responseCodes
 return412WithHeaders headers =
   pure . S.unifyTaggedUnion @"412" . (,headers)
 
-return413 :: Return413 a n m tags
+-- | Returns an HTTP 413 (Payload Too Large) typed response.
+return413 :: Return413 returnType index m responseCodes
 return413 = return413WithHeaders []
 
-return413WithHeaders :: HTTP.ResponseHeaders -> Return413 a n m tags
+{- | Returns an HTTP 413 (Payload Too Large) typed response with additional
+headers.
+-}
+return413WithHeaders :: HTTP.ResponseHeaders -> Return413 returnType index m responseCodes
 return413WithHeaders headers =
   pure . S.unifyTaggedUnion @"413" . (,headers)
 
-return414 :: Return414 a n m tags
+-- | Returns an HTTP 414 (URI Too Long) typed response.
+return414 :: Return414 returnType index m responseCodes
 return414 = return414WithHeaders []
 
-return414WithHeaders :: HTTP.ResponseHeaders -> Return414 a n m tags
+-- | Returns an HTTP 414 (URI Too Long) typed response with additional headers.
+return414WithHeaders :: HTTP.ResponseHeaders -> Return414 returnType index m responseCodes
 return414WithHeaders headers =
   pure . S.unifyTaggedUnion @"414" . (,headers)
 
-return415 :: Return415 a n m tags
+-- | Returns an HTTP 415 (Unsupported Media Type) typed response.
+return415 :: Return415 returnType index m responseCodes
 return415 = return415WithHeaders []
 
-return415WithHeaders :: HTTP.ResponseHeaders -> Return415 a n m tags
+{- | Returns an HTTP 415 (Unsupported Media Type) typed response with
+additional headers.
+-}
+return415WithHeaders :: HTTP.ResponseHeaders -> Return415 returnType index m responseCodes
 return415WithHeaders headers =
   pure . S.unifyTaggedUnion @"415" . (,headers)
 
-return416 :: Return416 a n m tags
+-- | Returns an HTTP 416 (Range Not Satisfiable) typed response.
+return416 :: Return416 returnType index m responseCodes
 return416 = return416WithHeaders []
 
-return416WithHeaders :: HTTP.ResponseHeaders -> Return416 a n m tags
+{- | Returns an HTTP 416 (Range Not Satisfiable) typed response with additional
+headers.
+-}
+return416WithHeaders :: HTTP.ResponseHeaders -> Return416 returnType index m responseCodes
 return416WithHeaders headers =
   pure . S.unifyTaggedUnion @"416" . (,headers)
 
-return417 :: Return417 a n m tags
+-- | Returns an HTTP 417 (Expectation Failed) typed response.
+return417 :: Return417 returnType index m responseCodes
 return417 = return417WithHeaders []
 
-return417WithHeaders :: HTTP.ResponseHeaders -> Return417 a n m tags
+{- | Returns an HTTP 417 (Expectation Failed) typed response with additional
+headers.
+-}
+return417WithHeaders :: HTTP.ResponseHeaders -> Return417 returnType index m responseCodes
 return417WithHeaders headers =
   pure . S.unifyTaggedUnion @"417" . (,headers)
 
-return418 :: Return418 a n m tags
+-- | Returns an HTTP 418 (I'm a Teapot) typed response.
+return418 :: Return418 returnType index m responseCodes
 return418 = return418WithHeaders []
 
-return418WithHeaders :: HTTP.ResponseHeaders -> Return418 a n m tags
+-- | Returns an HTTP 418 (I'm a Teapot) typed response with additional headers.
+return418WithHeaders :: HTTP.ResponseHeaders -> Return418 returnType index m responseCodes
 return418WithHeaders headers =
   pure . S.unifyTaggedUnion @"418" . (,headers)
 
-return422 :: Return422 a n m tags
+-- | Returns an HTTP 422 (Unprocessable Entity) typed response.
+return422 :: Return422 returnType index m responseCodes
 return422 = return422WithHeaders []
 
-return422WithHeaders :: HTTP.ResponseHeaders -> Return422 a n m tags
+{- | Returns an HTTP 422 (Unprocessable Entity) typed response with additional
+headers.
+-}
+return422WithHeaders :: HTTP.ResponseHeaders -> Return422 returnType index m responseCodes
 return422WithHeaders headers =
   pure . S.unifyTaggedUnion @"422" . (,headers)
 
-return428 :: Return428 a n m tags
+-- | Returns an HTTP 428 (Precondition Required) typed response.
+return428 :: Return428 returnType index m responseCodes
 return428 = return428WithHeaders []
 
-return428WithHeaders :: HTTP.ResponseHeaders -> Return428 a n m tags
+{- | Returns an HTTP 428 (Precondition Required) typed response with additional
+headers.
+-}
+return428WithHeaders :: HTTP.ResponseHeaders -> Return428 returnType index m responseCodes
 return428WithHeaders headers =
   pure . S.unifyTaggedUnion @"428" . (,headers)
 
-return429 :: Return429 a n m tags
+-- | Returns an HTTP 429 (Too Many Requests) typed response.
+return429 :: Return429 returnType index m responseCodes
 return429 = return429WithHeaders []
 
-return429WithHeaders :: HTTP.ResponseHeaders -> Return429 a n m tags
+{- | Returns an HTTP 429 (Too Many Requests) typed response with additional
+headers.
+-}
+return429WithHeaders :: HTTP.ResponseHeaders -> Return429 returnType index m responseCodes
 return429WithHeaders headers =
   pure . S.unifyTaggedUnion @"429" . (,headers)
 
-return431 :: Return431 a n m tags
+-- | Returns an HTTP 431 (Request Header Fields Too Large) typed response.
+return431 :: Return431 returnType index m responseCodes
 return431 = return431WithHeaders []
 
-return431WithHeaders :: HTTP.ResponseHeaders -> Return431 a n m tags
+{- | Returns an HTTP 431 (Request Header Fields Too Large) typed response with
+additional headers.
+-}
+return431WithHeaders :: HTTP.ResponseHeaders -> Return431 returnType index m responseCodes
 return431WithHeaders headers =
   pure . S.unifyTaggedUnion @"431" . (,headers)
 
-return500 :: Return500 a n m tags
+-- | Returns an HTTP 500 (Internal Server Error) typed response.
+return500 :: Return500 returnType index m responseCodes
 return500 = return500WithHeaders []
 
-return500WithHeaders :: HTTP.ResponseHeaders -> Return500 a n m tags
+{- | Returns an HTTP 500 (Internal Server Error) typed response with additional
+headers.
+-}
+return500WithHeaders :: HTTP.ResponseHeaders -> Return500 returnType index m responseCodes
 return500WithHeaders headers =
   pure . S.unifyTaggedUnion @"500" . (,headers)
 
-return501 :: Return501 a n m tags
+-- | Returns an HTTP 501 (Not Implemented) typed response.
+return501 :: Return501 returnType index m responseCodes
 return501 = return501WithHeaders []
 
-return501WithHeaders :: HTTP.ResponseHeaders -> Return501 a n m tags
+{- | Returns an HTTP 501 (Not Implemented) typed response with additional
+headers.
+-}
+return501WithHeaders :: HTTP.ResponseHeaders -> Return501 returnType index m responseCodes
 return501WithHeaders headers =
   pure . S.unifyTaggedUnion @"501" . (,headers)
 
-return502 :: Return502 a n m tags
+-- | Returns an HTTP 502 (Bad Gateway) typed response.
+return502 :: Return502 returnType index m responseCodes
 return502 = return502WithHeaders []
 
-return502WithHeaders :: HTTP.ResponseHeaders -> Return502 a n m tags
+-- | Returns an HTTP 502 (Bad Gateway) typed response with additional headers.
+return502WithHeaders :: HTTP.ResponseHeaders -> Return502 returnType index m responseCodes
 return502WithHeaders headers =
   pure . S.unifyTaggedUnion @"502" . (,headers)
 
-return503 :: Return503 a n m tags
+-- | Returns an HTTP 503 (Service Unavailable) typed response.
+return503 :: Return503 returnType index m responseCodes
 return503 = return503WithHeaders []
 
-return503WithHeaders :: HTTP.ResponseHeaders -> Return503 a n m tags
+{- | Returns an HTTP 503 (Service Unavailable) typed response with additional
+headers.
+-}
+return503WithHeaders :: HTTP.ResponseHeaders -> Return503 returnType index m responseCodes
 return503WithHeaders headers =
   pure . S.unifyTaggedUnion @"503" . (,headers)
 
-return504 :: Return504 a n m tags
+-- | Returns an HTTP 504 (Gateway Timeout) typed response.
+return504 :: Return504 returnType index m responseCodes
 return504 = return504WithHeaders []
 
-return504WithHeaders :: HTTP.ResponseHeaders -> Return504 a n m tags
+{- | Returns an HTTP 504 (Gateway Timeout) typed response with additional
+headers.
+-}
+return504WithHeaders :: HTTP.ResponseHeaders -> Return504 returnType index m responseCodes
 return504WithHeaders headers =
   pure . S.unifyTaggedUnion @"504" . (,headers)
 
-return505 :: Return505 a n m tags
+-- | Returns an HTTP 505 (HTTP Version Not Supported) typed response.
+return505 :: Return505 returnType index m responseCodes
 return505 = return505WithHeaders []
 
-return505WithHeaders :: HTTP.ResponseHeaders -> Return505 a n m tags
+{- | Returns an HTTP 505 (HTTP Version Not Supported) typed response with
+additional headers.
+-}
+return505WithHeaders :: HTTP.ResponseHeaders -> Return505 returnType index m responseCodes
 return505WithHeaders headers =
   pure . S.unifyTaggedUnion @"505" . (,headers)
 
-return511 :: Return511 a n m tags
+-- | Returns an HTTP 511 (Network Authentication Required) typed response.
+return511 :: Return511 returnType index m responseCodes
 return511 = return511WithHeaders []
 
-return511WithHeaders :: HTTP.ResponseHeaders -> Return511 a n m tags
+{- | Returns an HTTP 511 (Network Authentication Required) typed response with
+additional headers.
+-}
+return511WithHeaders :: HTTP.ResponseHeaders -> Return511 returnType index m responseCodes
 return511WithHeaders headers =
   pure . S.unifyTaggedUnion @"511" . (,headers)

--- a/src/Orb/Response/StatusCodes.hs
+++ b/src/Orb/Response/StatusCodes.hs
@@ -3081,768 +3081,1112 @@ type ReturnType returnType index m responseCodes code =
 
 {- | A type synonym representing a monadic action returning an HTTP 100
 (Continue) no-content response.
+
+@since 0.1.0
 -}
 type Return100 index m responseCodes =
   ReturnType NoContent index m responseCodes "100"
 
 {- | A type synonym representing a monadic action returning an HTTP 101
 (Switching Protocols) no-content response.
+
+@since 0.1.0
 -}
 type Return101 index m responseCodes =
   ReturnType NoContent index m responseCodes "101"
 
 {- | A type synonym representing a monadic action returning an HTTP 200 (OK)
 typed response.
+
+@since 0.1.0
 -}
 type Return200 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "200"
 
 {- | A type synonym representing a monadic action returning an HTTP 201
 (Created) typed response.
+
+@since 0.1.0
 -}
 type Return201 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "201"
 
 {- | A type synonym representing a monadic action returning an HTTP 202
 (Accepted) typed response.
+
+@since 0.1.0
 -}
 type Return202 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "202"
 
 {- | A type synonym representing a monadic action returning an HTTP 203
 (Non-Authoritative Information) typed response.
+
+@since 0.1.0
 -}
 type Return203 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "203"
 
 {- | A type synonym representing a monadic action returning an HTTP 204 (No
 Content) no-content response.
+
+@since 0.1.0
 -}
 type Return204 index m responseCodes =
   ReturnType NoContent index m responseCodes "204"
 
 {- | A type synonym representing a monadic action returning an HTTP 205 (Reset
 Content) no-content response.
+
+@since 0.1.0
 -}
 type Return205 index m responseCodes =
   ReturnType NoContent index m responseCodes "205"
 
 {- | A type synonym representing a monadic action returning an HTTP 206
 (Partial Content) typed response.
+
+@since 0.1.0
 -}
 type Return206 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "206"
 
 {- | A type synonym representing a monadic action returning an HTTP 300
 (Multiple Choices) typed response.
+
+@since 0.1.0
 -}
 type Return300 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "300"
 
 {- | A type synonym representing a monadic action returning an HTTP 301 (Moved
 Permanently) typed response.
+
+@since 0.1.0
 -}
 type Return301 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "301"
 
 {- | A type synonym representing a monadic action returning an HTTP 302 (Found)
 typed response.
+
+@since 0.1.0
 -}
 type Return302 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "302"
 
 {- | A type synonym representing a monadic action returning an HTTP 303 (See
 Other) typed response.
+
+@since 0.1.0
 -}
 type Return303 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "303"
 
 {- | A type synonym representing a monadic action returning an HTTP 304 (Not
 Modified) no-content response.
+
+@since 0.1.0
 -}
 type Return304 index m responseCodes =
   ReturnType NoContent index m responseCodes "304"
 
 {- | A type synonym representing a monadic action returning an HTTP 305 (Use
 Proxy) typed response.
+
+@since 0.1.0
 -}
 type Return305 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "305"
 
 {- | A type synonym representing a monadic action returning an HTTP 307
 (Temporary Redirect) typed response.
+
+@since 0.1.0
 -}
 type Return307 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "307"
 
 {- | A type synonym representing a monadic action returning an HTTP 308
 (Permanent Redirect) typed response.
+
+@since 0.1.0
 -}
 type Return308 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "308"
 
 {- | A type synonym representing a monadic action returning an HTTP 400 (Bad
 Request) typed response.
+
+@since 0.1.0
 -}
 type Return400 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "400"
 
 {- | A type synonym representing a monadic action returning an HTTP 401
 (Unauthorized) typed response.
+
+@since 0.1.0
 -}
 type Return401 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "401"
 
 {- | A type synonym representing a monadic action returning an HTTP 402
 (Payment Required) typed response.
+
+@since 0.1.0
 -}
 type Return402 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "402"
 
 {- | A type synonym representing a monadic action returning an HTTP 403
 (Forbidden) typed response.
+
+@since 0.1.0
 -}
 type Return403 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "403"
 
 {- | A type synonym representing a monadic action returning an HTTP 404 (Not
 Found) typed response.
+
+@since 0.1.0
 -}
 type Return404 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "404"
 
 {- | A type synonym representing a monadic action returning an HTTP 405 (Method
 Not Allowed) typed response.
+
+@since 0.1.0
 -}
 type Return405 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "405"
 
 {- | A type synonym representing a monadic action returning an HTTP 406 (Not
 Acceptable) typed response.
+
+@since 0.1.0
 -}
 type Return406 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "406"
 
 {- | A type synonym representing a monadic action returning an HTTP 407 (Proxy
 Authentication Required) typed response.
+
+@since 0.1.0
 -}
 type Return407 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "407"
 
 {- | A type synonym representing a monadic action returning an HTTP 408
 (Request Timeout) typed response.
+
+@since 0.1.0
 -}
 type Return408 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "408"
 
 {- | A type synonym representing a monadic action returning an HTTP 409
 (Conflict) typed response.
+
+@since 0.1.0
 -}
 type Return409 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "409"
 
 {- | A type synonym representing a monadic action returning an HTTP 410 (Gone)
 typed response.
+
+@since 0.1.0
 -}
 type Return410 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "410"
 
 {- | A type synonym representing a monadic action returning an HTTP 411 (Length
 Required) typed response.
+
+@since 0.1.0
 -}
 type Return411 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "411"
 
 {- | A type synonym representing a monadic action returning an HTTP 412
 (Precondition Failed) typed response.
+
+@since 0.1.0
 -}
 type Return412 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "412"
 
 {- | A type synonym representing a monadic action returning an HTTP 413
 (Payload Too Large) typed response.
+
+@since 0.1.0
 -}
 type Return413 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "413"
 
 {- | A type synonym representing a monadic action returning an HTTP 414 (URI
 Too Long) typed response.
+
+@since 0.1.0
 -}
 type Return414 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "414"
 
 {- | A type synonym representing a monadic action returning an HTTP 415
 (Unsupported Media Type) typed response.
+
+@since 0.1.0
 -}
 type Return415 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "415"
 
 {- | A type synonym representing a monadic action returning an HTTP 416 (Range
 Not Satisfiable) typed response.
+
+@since 0.1.0
 -}
 type Return416 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "416"
 
 {- | A type synonym representing a monadic action returning an HTTP 417
 (Expectation Failed) typed response.
+
+@since 0.1.0
 -}
 type Return417 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "417"
 
 {- | A type synonym representing a monadic action returning an HTTP 418 (I'm a
 Teapot) typed response.
+
+@since 0.1.0
 -}
 type Return418 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "418"
 
 {- | A type synonym representing a monadic action returning an HTTP 422
 (Unprocessable Entity) typed response.
+
+@since 0.1.0
 -}
 type Return422 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "422"
 
 {- | A type synonym representing a monadic action returning an HTTP 428
 (Precondition Required) typed response.
+
+@since 0.1.0
 -}
 type Return428 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "428"
 
 {- | A type synonym representing a monadic action returning an HTTP 429 (Too
 Many Requests) typed response.
+
+@since 0.1.0
 -}
 type Return429 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "429"
 
 {- | A type synonym representing a monadic action returning an HTTP 431
 (Request Header Fields Too Large) typed response.
+
+@since 0.1.0
 -}
 type Return431 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "431"
 
 {- | A type synonym representing a monadic action returning an HTTP 500
 (Internal Server Error) typed response.
+
+@since 0.1.0
 -}
 type Return500 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "500"
 
 {- | A type synonym representing a monadic action returning an HTTP 501 (Not
 Implemented) typed response.
+
+@since 0.1.0
 -}
 type Return501 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "501"
 
 {- | A type synonym representing a monadic action returning an HTTP 502 (Bad
 Gateway) typed response.
+
+@since 0.1.0
 -}
 type Return502 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "502"
 
 {- | A type synonym representing a monadic action returning an HTTP 503
 (Service Unavailable) typed response.
+
+@since 0.1.0
 -}
 type Return503 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "503"
 
 {- | A type synonym representing a monadic action returning an HTTP 504
 (Gateway Timeout) typed response.
+
+@since 0.1.0
 -}
 type Return504 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "504"
 
 {- | A type synonym representing a monadic action returning an HTTP 505 (HTTP
 Version Not Supported) typed response.
+
+@since 0.1.0
 -}
 type Return505 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "505"
 
 {- | A type synonym representing a monadic action returning an HTTP 511
 (Network Authentication Required) typed response.
+
+@since 0.1.0
 -}
 type Return511 returnType index m responseCodes =
   ReturnType returnType index m responseCodes "511"
 
--- | Returns an HTTP 100 (Continue) no-content response.
+{- | Returns an HTTP 100 (Continue) no-content response.
+
+@since 0.1.0
+-}
 return100 :: Return100 index m responseCodes
 return100 = return100WithHeaders []
 
 {- | Returns an HTTP 100 (Continue) no-content response with additional
 headers.
+
+@since 0.1.0
 -}
 return100WithHeaders :: HTTP.ResponseHeaders -> Return100 index m responseCodes
 return100WithHeaders headers =
   pure . S.unifyTaggedUnion @"100" . (,headers)
 
--- | Returns an HTTP 101 (Switching Protocols) no-content response.
+{- | Returns an HTTP 101 (Switching Protocols) no-content response.
+
+@since 0.1.0
+-}
 return101 :: Return101 index m responseCodes
 return101 = return101WithHeaders []
 
 {- | Returns an HTTP 101 (Switching Protocols) no-content response with
 additional headers.
+
+@since 0.1.0
 -}
 return101WithHeaders :: HTTP.ResponseHeaders -> Return101 index m responseCodes
 return101WithHeaders headers =
   pure . S.unifyTaggedUnion @"101" . (,headers)
 
--- | Returns an HTTP 200 (OK) typed response.
+{- | Returns an HTTP 200 (OK) typed response.
+
+@since 0.1.0
+-}
 return200 :: Return200 returnType index m responseCodes
 return200 = return200WithHeaders []
 
--- | Returns an HTTP 200 (OK) typed response with additional headers.
+{- | Returns an HTTP 200 (OK) typed response with additional headers.
+
+@since 0.1.0
+-}
 return200WithHeaders :: HTTP.ResponseHeaders -> Return200 returnType index m responseCodes
 return200WithHeaders headers =
   pure . S.unifyTaggedUnion @"200" . (,headers)
 
--- | Returns an HTTP 201 (Created) typed response.
+{- | Returns an HTTP 201 (Created) typed response.
+
+@since 0.1.0
+-}
 return201 :: Return201 returnType index m responseCodes
 return201 = return201WithHeaders []
 
--- | Returns an HTTP 201 (Created) typed response with additional headers.
+{- | Returns an HTTP 201 (Created) typed response with additional headers.
+
+@since 0.1.0
+-}
 return201WithHeaders :: HTTP.ResponseHeaders -> Return201 returnType index m responseCodes
 return201WithHeaders headers =
   pure . S.unifyTaggedUnion @"201" . (,headers)
 
--- | Returns an HTTP 202 (Accepted) typed response.
+{- | Returns an HTTP 202 (Accepted) typed response.
+
+@since 0.1.0
+-}
 return202 :: Return202 returnType index m responseCodes
 return202 = return202WithHeaders []
 
--- | Returns an HTTP 202 (Accepted) typed response with additional headers.
+{- | Returns an HTTP 202 (Accepted) typed response with additional headers.
+
+@since 0.1.0
+-}
 return202WithHeaders :: HTTP.ResponseHeaders -> Return202 returnType index m responseCodes
 return202WithHeaders headers =
   pure . S.unifyTaggedUnion @"202" . (,headers)
 
--- | Returns an HTTP 203 (Non-Authoritative Information) typed response.
+{- | Returns an HTTP 203 (Non-Authoritative Information) typed response.
+
+@since 0.1.0
+-}
 return203 :: Return203 returnType index m responseCodes
 return203 = return203WithHeaders []
 
 {- | Returns an HTTP 203 (Non-Authoritative Information) typed response with
 additional headers.
+
+@since 0.1.0
 -}
 return203WithHeaders :: HTTP.ResponseHeaders -> Return203 returnType index m responseCodes
 return203WithHeaders headers =
   pure . S.unifyTaggedUnion @"203" . (,headers)
 
--- | Returns an HTTP 204 (No Content) no-content response.
+{- | Returns an HTTP 204 (No Content) no-content response.
+
+@since 0.1.0
+-}
 return204 :: Return204 index m responseCodes
 return204 = return204WithHeaders []
 
 {- | Returns an HTTP 204 (No Content) no-content response with additional
 headers.
+
+@since 0.1.0
 -}
 return204WithHeaders :: HTTP.ResponseHeaders -> Return204 index m responseCodes
 return204WithHeaders headers =
   pure . S.unifyTaggedUnion @"204" . (,headers)
 
--- | Returns an HTTP 205 (Reset Content) no-content response.
+{- | Returns an HTTP 205 (Reset Content) no-content response.
+
+@since 0.1.0
+-}
 return205 :: Return205 index m responseCodes
 return205 = return205WithHeaders []
 
 {- | Returns an HTTP 205 (Reset Content) no-content response with additional
 headers.
+
+@since 0.1.0
 -}
 return205WithHeaders :: HTTP.ResponseHeaders -> Return205 index m responseCodes
 return205WithHeaders headers =
   pure . S.unifyTaggedUnion @"205" . (,headers)
 
--- | Returns an HTTP 206 (Partial Content) typed response.
+{- | Returns an HTTP 206 (Partial Content) typed response.
+
+@since 0.1.0
+-}
 return206 :: Return206 returnType index m responseCodes
 return206 = return206WithHeaders []
 
 {- | Returns an HTTP 206 (Partial Content) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return206WithHeaders :: HTTP.ResponseHeaders -> Return206 returnType index m responseCodes
 return206WithHeaders headers =
   pure . S.unifyTaggedUnion @"206" . (,headers)
 
--- | Returns an HTTP 300 (Multiple Choices) typed response.
+{- | Returns an HTTP 300 (Multiple Choices) typed response.
+
+@since 0.1.0
+-}
 return300 :: Return300 returnType index m responseCodes
 return300 = return300WithHeaders []
 
 {- | Returns an HTTP 300 (Multiple Choices) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return300WithHeaders :: HTTP.ResponseHeaders -> Return300 returnType index m responseCodes
 return300WithHeaders headers =
   pure . S.unifyTaggedUnion @"300" . (,headers)
 
--- | Returns an HTTP 301 (Moved Permanently) typed response.
+{- | Returns an HTTP 301 (Moved Permanently) typed response.
+
+@since 0.1.0
+-}
 return301 :: Return301 returnType index m responseCodes
 return301 = return301WithHeaders []
 
 {- | Returns an HTTP 301 (Moved Permanently) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return301WithHeaders :: HTTP.ResponseHeaders -> Return301 returnType index m responseCodes
 return301WithHeaders headers =
   pure . S.unifyTaggedUnion @"301" . (,headers)
 
--- | Returns an HTTP 302 (Found) typed response.
+{- | Returns an HTTP 302 (Found) typed response.
+
+@since 0.1.0
+-}
 return302 :: Return302 returnType index m responseCodes
 return302 = return302WithHeaders []
 
--- | Returns an HTTP 302 (Found) typed response with additional headers.
+{- | Returns an HTTP 302 (Found) typed response with additional headers.
+
+@since 0.1.0
+-}
 return302WithHeaders :: HTTP.ResponseHeaders -> Return302 returnType index m responseCodes
 return302WithHeaders headers =
   pure . S.unifyTaggedUnion @"302" . (,headers)
 
--- | Returns an HTTP 303 (See Other) typed response.
+{- | Returns an HTTP 303 (See Other) typed response.
+
+@since 0.1.0
+-}
 return303 :: Return303 returnType index m responseCodes
 return303 = return303WithHeaders []
 
--- | Returns an HTTP 303 (See Other) typed response with additional headers.
+{- | Returns an HTTP 303 (See Other) typed response with additional headers.
+
+@since 0.1.0
+-}
 return303WithHeaders :: HTTP.ResponseHeaders -> Return303 returnType index m responseCodes
 return303WithHeaders headers =
   pure . S.unifyTaggedUnion @"303" . (,headers)
 
--- | Returns an HTTP 304 (Not Modified) no-content response.
+{- | Returns an HTTP 304 (Not Modified) no-content response.
+
+@since 0.1.0
+-}
 return304 :: Return304 index m responseCodes
 return304 = return304WithHeaders []
 
 {- | Returns an HTTP 304 (Not Modified) no-content response with additional
 headers.
+
+@since 0.1.0
 -}
 return304WithHeaders :: HTTP.ResponseHeaders -> Return304 index m responseCodes
 return304WithHeaders headers =
   pure . S.unifyTaggedUnion @"304" . (,headers)
 
--- | Returns an HTTP 305 (Use Proxy) typed response.
+{- | Returns an HTTP 305 (Use Proxy) typed response.
+
+@since 0.1.0
+-}
 return305 :: Return305 returnType index m responseCodes
 return305 = return305WithHeaders []
 
--- | Returns an HTTP 305 (Use Proxy) typed response with additional headers.
+{- | Returns an HTTP 305 (Use Proxy) typed response with additional headers.
+
+@since 0.1.0
+-}
 return305WithHeaders :: HTTP.ResponseHeaders -> Return305 returnType index m responseCodes
 return305WithHeaders headers =
   pure . S.unifyTaggedUnion @"305" . (,headers)
 
--- | Returns an HTTP 307 (Temporary Redirect) typed response.
+{- | Returns an HTTP 307 (Temporary Redirect) typed response.
+
+@since 0.1.0
+-}
 return307 :: Return307 returnType index m responseCodes
 return307 = return307WithHeaders []
 
 {- | Returns an HTTP 307 (Temporary Redirect) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return307WithHeaders :: HTTP.ResponseHeaders -> Return307 returnType index m responseCodes
 return307WithHeaders headers =
   pure . S.unifyTaggedUnion @"307" . (,headers)
 
--- | Returns an HTTP 308 (Permanent Redirect) typed response.
+{- | Returns an HTTP 308 (Permanent Redirect) typed response.
+
+@since 0.1.0
+-}
 return308 :: Return308 returnType index m responseCodes
 return308 = return308WithHeaders []
 
 {- | Returns an HTTP 308 (Permanent Redirect) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return308WithHeaders :: HTTP.ResponseHeaders -> Return308 returnType index m responseCodes
 return308WithHeaders headers =
   pure . S.unifyTaggedUnion @"308" . (,headers)
 
--- | Returns an HTTP 400 (Bad Request) typed response.
+{- | Returns an HTTP 400 (Bad Request) typed response.
+
+@since 0.1.0
+-}
 return400 :: Return400 returnType index m responseCodes
 return400 = return400WithHeaders []
 
--- | Returns an HTTP 400 (Bad Request) typed response with additional headers.
+{- | Returns an HTTP 400 (Bad Request) typed response with additional headers.
+
+@since 0.1.0
+-}
 return400WithHeaders :: HTTP.ResponseHeaders -> Return400 returnType index m responseCodes
 return400WithHeaders headers =
   pure . S.unifyTaggedUnion @"400" . (,headers)
 
--- | Returns an HTTP 401 (Unauthorized) typed response.
+{- | Returns an HTTP 401 (Unauthorized) typed response.
+
+@since 0.1.0
+-}
 return401 :: Return401 returnType index m responseCodes
 return401 = return401WithHeaders []
 
--- | Returns an HTTP 401 (Unauthorized) typed response with additional headers.
+{- | Returns an HTTP 401 (Unauthorized) typed response with additional headers.
+
+@since 0.1.0
+-}
 return401WithHeaders :: HTTP.ResponseHeaders -> Return401 returnType index m responseCodes
 return401WithHeaders headers =
   pure . S.unifyTaggedUnion @"401" . (,headers)
 
--- | Returns an HTTP 402 (Payment Required) typed response.
+{- | Returns an HTTP 402 (Payment Required) typed response.
+
+@since 0.1.0
+-}
 return402 :: Return402 returnType index m responseCodes
 return402 = return402WithHeaders []
 
 {- | Returns an HTTP 402 (Payment Required) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return402WithHeaders :: HTTP.ResponseHeaders -> Return402 returnType index m responseCodes
 return402WithHeaders headers =
   pure . S.unifyTaggedUnion @"402" . (,headers)
 
--- | Returns an HTTP 403 (Forbidden) typed response.
+{- | Returns an HTTP 403 (Forbidden) typed response.
+
+@since 0.1.0
+-}
 return403 :: Return403 returnType index m responseCodes
 return403 = return403WithHeaders []
 
--- | Returns an HTTP 403 (Forbidden) typed response with additional headers.
+{- | Returns an HTTP 403 (Forbidden) typed response with additional headers.
+
+@since 0.1.0
+-}
 return403WithHeaders :: HTTP.ResponseHeaders -> Return403 returnType index m responseCodes
 return403WithHeaders headers =
   pure . S.unifyTaggedUnion @"403" . (,headers)
 
--- | Returns an HTTP 404 (Not Found) typed response.
+{- | Returns an HTTP 404 (Not Found) typed response.
+
+@since 0.1.0
+-}
 return404 :: Return404 returnType index m responseCodes
 return404 = return404WithHeaders []
 
--- | Returns an HTTP 404 (Not Found) typed response with additional headers.
+{- | Returns an HTTP 404 (Not Found) typed response with additional headers.
+
+@since 0.1.0
+-}
 return404WithHeaders :: HTTP.ResponseHeaders -> Return404 returnType index m responseCodes
 return404WithHeaders headers =
   pure . S.unifyTaggedUnion @"404" . (,headers)
 
--- | Returns an HTTP 405 (Method Not Allowed) typed response.
+{- | Returns an HTTP 405 (Method Not Allowed) typed response.
+
+@since 0.1.0
+-}
 return405 :: Return405 returnType index m responseCodes
 return405 = return405WithHeaders []
 
 {- | Returns an HTTP 405 (Method Not Allowed) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return405WithHeaders :: HTTP.ResponseHeaders -> Return405 returnType index m responseCodes
 return405WithHeaders headers =
   pure . S.unifyTaggedUnion @"405" . (,headers)
 
--- | Returns an HTTP 406 (Not Acceptable) typed response.
+{- | Returns an HTTP 406 (Not Acceptable) typed response.
+
+@since 0.1.0
+-}
 return406 :: Return406 returnType index m responseCodes
 return406 = return406WithHeaders []
 
 {- | Returns an HTTP 406 (Not Acceptable) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return406WithHeaders :: HTTP.ResponseHeaders -> Return406 returnType index m responseCodes
 return406WithHeaders headers =
   pure . S.unifyTaggedUnion @"406" . (,headers)
 
--- | Returns an HTTP 407 (Proxy Authentication Required) typed response.
+{- | Returns an HTTP 407 (Proxy Authentication Required) typed response.
+
+@since 0.1.0
+-}
 return407 :: Return407 returnType index m responseCodes
 return407 = return407WithHeaders []
 
 {- | Returns an HTTP 407 (Proxy Authentication Required) typed response with
 additional headers.
+
+@since 0.1.0
 -}
 return407WithHeaders :: HTTP.ResponseHeaders -> Return407 returnType index m responseCodes
 return407WithHeaders headers =
   pure . S.unifyTaggedUnion @"407" . (,headers)
 
--- | Returns an HTTP 408 (Request Timeout) typed response.
+{- | Returns an HTTP 408 (Request Timeout) typed response.
+
+@since 0.1.0
+-}
 return408 :: Return408 returnType index m responseCodes
 return408 = return408WithHeaders []
 
 {- | Returns an HTTP 408 (Request Timeout) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return408WithHeaders :: HTTP.ResponseHeaders -> Return408 returnType index m responseCodes
 return408WithHeaders headers =
   pure . S.unifyTaggedUnion @"408" . (,headers)
 
--- | Returns an HTTP 409 (Conflict) typed response.
+{- | Returns an HTTP 409 (Conflict) typed response.
+
+@since 0.1.0
+-}
 return409 :: Return409 returnType index m responseCodes
 return409 = return409WithHeaders []
 
--- | Returns an HTTP 409 (Conflict) typed response with additional headers.
+{- | Returns an HTTP 409 (Conflict) typed response with additional headers.
+
+@since 0.1.0
+-}
 return409WithHeaders :: HTTP.ResponseHeaders -> Return409 returnType index m responseCodes
 return409WithHeaders headers =
   pure . S.unifyTaggedUnion @"409" . (,headers)
 
--- | Returns an HTTP 410 (Gone) typed response.
+{- | Returns an HTTP 410 (Gone) typed response.
+
+@since 0.1.0
+-}
 return410 :: Return410 returnType index m responseCodes
 return410 = return410WithHeaders []
 
--- | Returns an HTTP 410 (Gone) typed response with additional headers.
+{- | Returns an HTTP 410 (Gone) typed response with additional headers.
+
+@since 0.1.0
+-}
 return410WithHeaders :: HTTP.ResponseHeaders -> Return410 returnType index m responseCodes
 return410WithHeaders headers =
   pure . S.unifyTaggedUnion @"410" . (,headers)
 
--- | Returns an HTTP 411 (Length Required) typed response.
+{- | Returns an HTTP 411 (Length Required) typed response.
+
+@since 0.1.0
+-}
 return411 :: Return411 returnType index m responseCodes
 return411 = return411WithHeaders []
 
 {- | Returns an HTTP 411 (Length Required) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return411WithHeaders :: HTTP.ResponseHeaders -> Return411 returnType index m responseCodes
 return411WithHeaders headers =
   pure . S.unifyTaggedUnion @"411" . (,headers)
 
--- | Returns an HTTP 412 (Precondition Failed) typed response.
+{- | Returns an HTTP 412 (Precondition Failed) typed response.
+
+@since 0.1.0
+-}
 return412 :: Return412 returnType index m responseCodes
 return412 = return412WithHeaders []
 
 {- | Returns an HTTP 412 (Precondition Failed) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return412WithHeaders :: HTTP.ResponseHeaders -> Return412 returnType index m responseCodes
 return412WithHeaders headers =
   pure . S.unifyTaggedUnion @"412" . (,headers)
 
--- | Returns an HTTP 413 (Payload Too Large) typed response.
+{- | Returns an HTTP 413 (Payload Too Large) typed response.
+
+@since 0.1.0
+-}
 return413 :: Return413 returnType index m responseCodes
 return413 = return413WithHeaders []
 
 {- | Returns an HTTP 413 (Payload Too Large) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return413WithHeaders :: HTTP.ResponseHeaders -> Return413 returnType index m responseCodes
 return413WithHeaders headers =
   pure . S.unifyTaggedUnion @"413" . (,headers)
 
--- | Returns an HTTP 414 (URI Too Long) typed response.
+{- | Returns an HTTP 414 (URI Too Long) typed response.
+
+@since 0.1.0
+-}
 return414 :: Return414 returnType index m responseCodes
 return414 = return414WithHeaders []
 
--- | Returns an HTTP 414 (URI Too Long) typed response with additional headers.
+{- | Returns an HTTP 414 (URI Too Long) typed response with additional headers.
+
+@since 0.1.0
+-}
 return414WithHeaders :: HTTP.ResponseHeaders -> Return414 returnType index m responseCodes
 return414WithHeaders headers =
   pure . S.unifyTaggedUnion @"414" . (,headers)
 
--- | Returns an HTTP 415 (Unsupported Media Type) typed response.
+{- | Returns an HTTP 415 (Unsupported Media Type) typed response.
+
+@since 0.1.0
+-}
 return415 :: Return415 returnType index m responseCodes
 return415 = return415WithHeaders []
 
 {- | Returns an HTTP 415 (Unsupported Media Type) typed response with
 additional headers.
+
+@since 0.1.0
 -}
 return415WithHeaders :: HTTP.ResponseHeaders -> Return415 returnType index m responseCodes
 return415WithHeaders headers =
   pure . S.unifyTaggedUnion @"415" . (,headers)
 
--- | Returns an HTTP 416 (Range Not Satisfiable) typed response.
+{- | Returns an HTTP 416 (Range Not Satisfiable) typed response.
+
+@since 0.1.0
+-}
 return416 :: Return416 returnType index m responseCodes
 return416 = return416WithHeaders []
 
 {- | Returns an HTTP 416 (Range Not Satisfiable) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return416WithHeaders :: HTTP.ResponseHeaders -> Return416 returnType index m responseCodes
 return416WithHeaders headers =
   pure . S.unifyTaggedUnion @"416" . (,headers)
 
--- | Returns an HTTP 417 (Expectation Failed) typed response.
+{- | Returns an HTTP 417 (Expectation Failed) typed response.
+
+@since 0.1.0
+-}
 return417 :: Return417 returnType index m responseCodes
 return417 = return417WithHeaders []
 
 {- | Returns an HTTP 417 (Expectation Failed) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return417WithHeaders :: HTTP.ResponseHeaders -> Return417 returnType index m responseCodes
 return417WithHeaders headers =
   pure . S.unifyTaggedUnion @"417" . (,headers)
 
--- | Returns an HTTP 418 (I'm a Teapot) typed response.
+{- | Returns an HTTP 418 (I'm a Teapot) typed response.
+
+@since 0.1.0
+-}
 return418 :: Return418 returnType index m responseCodes
 return418 = return418WithHeaders []
 
--- | Returns an HTTP 418 (I'm a Teapot) typed response with additional headers.
+{- | Returns an HTTP 418 (I'm a Teapot) typed response with additional headers.
+
+@since 0.1.0
+-}
 return418WithHeaders :: HTTP.ResponseHeaders -> Return418 returnType index m responseCodes
 return418WithHeaders headers =
   pure . S.unifyTaggedUnion @"418" . (,headers)
 
--- | Returns an HTTP 422 (Unprocessable Entity) typed response.
+{- | Returns an HTTP 422 (Unprocessable Entity) typed response.
+
+@since 0.1.0
+-}
 return422 :: Return422 returnType index m responseCodes
 return422 = return422WithHeaders []
 
 {- | Returns an HTTP 422 (Unprocessable Entity) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return422WithHeaders :: HTTP.ResponseHeaders -> Return422 returnType index m responseCodes
 return422WithHeaders headers =
   pure . S.unifyTaggedUnion @"422" . (,headers)
 
--- | Returns an HTTP 428 (Precondition Required) typed response.
+{- | Returns an HTTP 428 (Precondition Required) typed response.
+
+@since 0.1.0
+-}
 return428 :: Return428 returnType index m responseCodes
 return428 = return428WithHeaders []
 
 {- | Returns an HTTP 428 (Precondition Required) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return428WithHeaders :: HTTP.ResponseHeaders -> Return428 returnType index m responseCodes
 return428WithHeaders headers =
   pure . S.unifyTaggedUnion @"428" . (,headers)
 
--- | Returns an HTTP 429 (Too Many Requests) typed response.
+{- | Returns an HTTP 429 (Too Many Requests) typed response.
+
+@since 0.1.0
+-}
 return429 :: Return429 returnType index m responseCodes
 return429 = return429WithHeaders []
 
 {- | Returns an HTTP 429 (Too Many Requests) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return429WithHeaders :: HTTP.ResponseHeaders -> Return429 returnType index m responseCodes
 return429WithHeaders headers =
   pure . S.unifyTaggedUnion @"429" . (,headers)
 
--- | Returns an HTTP 431 (Request Header Fields Too Large) typed response.
+{- | Returns an HTTP 431 (Request Header Fields Too Large) typed response.
+
+@since 0.1.0
+-}
 return431 :: Return431 returnType index m responseCodes
 return431 = return431WithHeaders []
 
 {- | Returns an HTTP 431 (Request Header Fields Too Large) typed response with
 additional headers.
+
+@since 0.1.0
 -}
 return431WithHeaders :: HTTP.ResponseHeaders -> Return431 returnType index m responseCodes
 return431WithHeaders headers =
   pure . S.unifyTaggedUnion @"431" . (,headers)
 
--- | Returns an HTTP 500 (Internal Server Error) typed response.
+{- | Returns an HTTP 500 (Internal Server Error) typed response.
+
+@since 0.1.0
+-}
 return500 :: Return500 returnType index m responseCodes
 return500 = return500WithHeaders []
 
 {- | Returns an HTTP 500 (Internal Server Error) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return500WithHeaders :: HTTP.ResponseHeaders -> Return500 returnType index m responseCodes
 return500WithHeaders headers =
   pure . S.unifyTaggedUnion @"500" . (,headers)
 
--- | Returns an HTTP 501 (Not Implemented) typed response.
+{- | Returns an HTTP 501 (Not Implemented) typed response.
+
+@since 0.1.0
+-}
 return501 :: Return501 returnType index m responseCodes
 return501 = return501WithHeaders []
 
 {- | Returns an HTTP 501 (Not Implemented) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return501WithHeaders :: HTTP.ResponseHeaders -> Return501 returnType index m responseCodes
 return501WithHeaders headers =
   pure . S.unifyTaggedUnion @"501" . (,headers)
 
--- | Returns an HTTP 502 (Bad Gateway) typed response.
+{- | Returns an HTTP 502 (Bad Gateway) typed response.
+
+@since 0.1.0
+-}
 return502 :: Return502 returnType index m responseCodes
 return502 = return502WithHeaders []
 
--- | Returns an HTTP 502 (Bad Gateway) typed response with additional headers.
+{- | Returns an HTTP 502 (Bad Gateway) typed response with additional headers.
+
+@since 0.1.0
+-}
 return502WithHeaders :: HTTP.ResponseHeaders -> Return502 returnType index m responseCodes
 return502WithHeaders headers =
   pure . S.unifyTaggedUnion @"502" . (,headers)
 
--- | Returns an HTTP 503 (Service Unavailable) typed response.
+{- | Returns an HTTP 503 (Service Unavailable) typed response.
+
+@since 0.1.0
+-}
 return503 :: Return503 returnType index m responseCodes
 return503 = return503WithHeaders []
 
 {- | Returns an HTTP 503 (Service Unavailable) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return503WithHeaders :: HTTP.ResponseHeaders -> Return503 returnType index m responseCodes
 return503WithHeaders headers =
   pure . S.unifyTaggedUnion @"503" . (,headers)
 
--- | Returns an HTTP 504 (Gateway Timeout) typed response.
+{- | Returns an HTTP 504 (Gateway Timeout) typed response.
+
+@since 0.1.0
+-}
 return504 :: Return504 returnType index m responseCodes
 return504 = return504WithHeaders []
 
 {- | Returns an HTTP 504 (Gateway Timeout) typed response with additional
 headers.
+
+@since 0.1.0
 -}
 return504WithHeaders :: HTTP.ResponseHeaders -> Return504 returnType index m responseCodes
 return504WithHeaders headers =
   pure . S.unifyTaggedUnion @"504" . (,headers)
 
--- | Returns an HTTP 505 (HTTP Version Not Supported) typed response.
+{- | Returns an HTTP 505 (HTTP Version Not Supported) typed response.
+
+@since 0.1.0
+-}
 return505 :: Return505 returnType index m responseCodes
 return505 = return505WithHeaders []
 
 {- | Returns an HTTP 505 (HTTP Version Not Supported) typed response with
 additional headers.
+
+@since 0.1.0
 -}
 return505WithHeaders :: HTTP.ResponseHeaders -> Return505 returnType index m responseCodes
 return505WithHeaders headers =
   pure . S.unifyTaggedUnion @"505" . (,headers)
 
--- | Returns an HTTP 511 (Network Authentication Required) typed response.
+{- | Returns an HTTP 511 (Network Authentication Required) typed response.
+
+@since 0.1.0
+-}
 return511 :: Return511 returnType index m responseCodes
 return511 = return511WithHeaders []
 
 {- | Returns an HTTP 511 (Network Authentication Required) typed response with
 additional headers.
+
+@since 0.1.0
 -}
 return511WithHeaders :: HTTP.ResponseHeaders -> Return511 returnType index m responseCodes
 return511WithHeaders headers =


### PR DESCRIPTION
This adds helpers for all supported HTTP status codes defined in `Network.HTTP.Types`. Only valid helpers are provided (for example, no document response builder for 204 responses). A version of `returnXXX` that supports user-defined headers was included for all status codes.