### PR TITLE
Adds support for requests with form data request bodies

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -33,6 +33,7 @@ library
   other-modules:
       Orb.Handler
       Orb.Handler.Dispatchable
+      Orb.Handler.Form
       Orb.Handler.Handler
       Orb.Handler.PermissionAction
       Orb.Handler.PermissionError
@@ -61,6 +62,7 @@ library
     , text
     , unliftio
     , wai
+    , wai-extra
   default-language: Haskell2010
   if flag(ci)
     ghc-options: -O2 -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wnoncanonical-monad-instances -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe -fwrite-ide-info -hiedir=.hie
@@ -88,4 +90,5 @@ test-suite orb-test
     , text
     , unliftio
     , wai
+    , wai-extra
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ dependencies:
   - text
   - unliftio
   - wai
+  - wai-extra
 
 library:
   source-dirs: src

--- a/src/Orb/Handler.hs
+++ b/src/Orb/Handler.hs
@@ -4,6 +4,7 @@ module Orb.Handler
 where
 
 import Orb.Handler.Dispatchable as Export
+import Orb.Handler.Form as Export
 import Orb.Handler.Handler as Export
 import Orb.Handler.PermissionAction as Export
 import Orb.Handler.PermissionError as Export

--- a/src/Orb/Handler/Form.hs
+++ b/src/Orb/Handler/Form.hs
@@ -16,14 +16,16 @@ import Network.Wai.Parse qualified as Wai
 
 type Form = Map.Map T.Text FormField
 
-getForm :: ([Wai.Param], [Wai.File LBS.ByteString]) -> Either String Form
+getForm :: ([Wai.Param], [Wai.File LBS.ByteString]) -> Either T.Text Form
 getForm (params, files) =
   mergeA
     (traverseMissing $ \_lk lv -> Right lv)
     (traverseMissing $ \_rk rv -> Right rv)
     ( zipWithAMatched $ \k _lv _rv ->
         Left $
-          "Form field with name " <> T.unpack k <> " appears more than once."
+          T.pack "Form field with name "
+            <> k
+            <> T.pack " appears more than once."
     )
     (ParamField <$> foldl' insertParamField Map.empty params)
     (FileField <$> foldl' insertFileField Map.empty files)

--- a/src/Orb/Handler/Form.hs
+++ b/src/Orb/Handler/Form.hs
@@ -1,0 +1,55 @@
+module Orb.Handler.Form
+  ( Form
+  , getForm
+  , FormField (..)
+  ) where
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LBS
+import Data.List (foldl')
+import Data.List.NonEmpty qualified as NEL
+import Data.Map.Merge.Strict (mergeA, traverseMissing, zipWithAMatched)
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+import Data.Text.Encoding qualified as TE
+import Network.Wai.Parse qualified as Wai
+
+type Form = Map.Map T.Text FormField
+
+getForm :: ([Wai.Param], [Wai.File LBS.ByteString]) -> Either String Form
+getForm (params, files) =
+  mergeA
+    (traverseMissing $ \_lk lv -> Right lv)
+    (traverseMissing $ \_rk rv -> Right rv)
+    ( zipWithAMatched $ \k _lv _rv ->
+        Left $
+          "Form field with name " <> T.unpack k <> " appears more than once."
+    )
+    (ParamField <$> foldl' insertParamField Map.empty params)
+    (FileField <$> foldl' insertFileField Map.empty files)
+
+insertParamField ::
+  Map.Map T.Text (NEL.NonEmpty T.Text) ->
+  (BS.ByteString, BS.ByteString) ->
+  Map.Map T.Text (NEL.NonEmpty T.Text)
+insertParamField params (k, v) =
+  Map.insertWith
+    (<>)
+    (TE.decodeUtf8 k)
+    (NEL.singleton $ TE.decodeUtf8 v)
+    params
+
+insertFileField ::
+  Map.Map T.Text (NEL.NonEmpty (Wai.FileInfo LBS.ByteString)) ->
+  (BS.ByteString, Wai.FileInfo LBS.ByteString) ->
+  Map.Map T.Text (NEL.NonEmpty (Wai.FileInfo LBS.ByteString))
+insertFileField files (k, v) =
+  Map.insertWith
+    (<>)
+    (TE.decodeUtf8 k)
+    (NEL.singleton v)
+    files
+
+data FormField
+  = ParamField (NEL.NonEmpty T.Text)
+  | FileField (NEL.NonEmpty (Wai.FileInfo LBS.ByteString))

--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -23,10 +23,13 @@ where
 import Data.ByteString.Lazy qualified as LBS
 import Data.Kind qualified as Kind
 import Data.Maybe (maybeToList)
+import Data.Text qualified as T
 import Network.Wai qualified as Wai
+import Network.Wai.Parse qualified as Wai
 import Shrubbery qualified as S
 import UnliftIO qualified
 
+import Orb.Handler.Form (Form, getForm)
 import Orb.Handler.PermissionAction qualified as PA
 import Orb.Handler.PermissionError qualified as PE
 import Orb.HasRequest qualified as HasRequest
@@ -85,6 +88,10 @@ data RequestBody body tags where
     Response.HasResponseCodeWithType tags "422" err =>
     (LBS.ByteString -> Either err body) ->
     RequestBody body tags
+  RequestFormData ::
+    (Response.Has400Response tags, Response.HasResponseCodeWithType tags "422" err) =>
+    (Form -> Either err body) ->
+    RequestBody body tags
   EmptyRequestBody ::
     RequestBody NoRequestBody tags
 
@@ -103,6 +110,11 @@ runHandler handler route =
     RequestBody bodyDecoder ->
       requestBodyHandler
         bodyDecoder
+        (handlerResponseBodies handler)
+        (runPermissionAction handler route)
+    RequestFormData formDecoder ->
+      requestFormDataHandler
+        formDecoder
         (handlerResponseBodies handler)
         (runPermissionAction handler route)
     EmptyRequestBody ->
@@ -157,6 +169,41 @@ emptyRequestBodyHandler bodies action = do
       (Response.responseDataStatus responseData)
       (contentTypeHeader <> Response.responseDataExtraHeaders responseData)
       (Response.responseDataBytes responseData)
+
+requestFormDataHandler ::
+  ( Response.Has400Response tags
+  , Response.HasResponseCodeWithType tags "422" err
+  , Response.Has500Response tags
+  , HasRequest.HasRequest m
+  , HasRespond.HasRespond m
+  , UnliftIO.MonadUnliftIO m
+  ) =>
+  (Form -> Either err request) ->
+  Response.ResponseBodies tags ->
+  (request -> m (S.TaggedUnion tags)) ->
+  m Wai.ResponseReceived
+requestFormDataHandler requestDecoder bodies action =
+  emptyRequestBodyHandler bodies $ do
+    req <- HasRequest.request
+    errOrFormFields <-
+      UnliftIO.liftIO $
+        UnliftIO.try $
+          Wai.parseRequestBodyEx
+            Wai.defaultParseRequestBodyOptions
+            Wai.lbsBackEnd
+            req
+
+    case errOrFormFields of
+      Left (err :: Wai.RequestParseException) ->
+        Response.return400 . Response.BadRequestMessage . T.pack $ show err
+      Right formFields ->
+        case getForm formFields of
+          Left err ->
+            Response.return400 . Response.BadRequestMessage $ T.pack err
+          Right form ->
+            case requestDecoder form of
+              Left err -> Response.return422 err
+              Right request -> action request
 
 requestBodyHandler ::
   ( Response.HasResponseCodeWithType tags "422" err

--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -186,12 +186,12 @@ requestFormDataHandler requestDecoder bodies action =
   emptyRequestBodyHandler bodies $ do
     req <- HasRequest.request
     errOrFormFields <-
-      UnliftIO.liftIO $
-        UnliftIO.try $
-          Wai.parseRequestBodyEx
-            Wai.defaultParseRequestBodyOptions
-            Wai.lbsBackEnd
-            req
+      UnliftIO.liftIO
+        . UnliftIO.try
+        $ Wai.parseRequestBodyEx
+          Wai.defaultParseRequestBodyOptions
+          Wai.lbsBackEnd
+          req
 
     case errOrFormFields of
       Left (err :: Wai.RequestParseException) ->
@@ -199,7 +199,7 @@ requestFormDataHandler requestDecoder bodies action =
       Right formFields ->
         case getForm formFields of
           Left err ->
-            Response.return400 . Response.BadRequestMessage $ T.pack err
+            Response.return400 $ Response.BadRequestMessage err
           Right form ->
             case requestDecoder form of
               Left err -> Response.return422 err


### PR DESCRIPTION
This adds another constructor for `RequestBody` that handles `multipart/form-data`. We interpret the form fields as a mapping of field name to content, be it a data param or a file upload. This makes it easy for users to search by the field name or ID. A user provided function that validates that form allows us to respond with a 422 containing the validation errors in the manner the user chooses.

This is designed to support fields that can have more than one value (checkboxes, multi-select, the `multiple` attribute), allowing for a (non-empty) list of values for any given field name. We reject forms when a param and a file share the same field name.