### PR TITLE
Adds logging support via HasLogger type class

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -36,6 +36,7 @@ library
       Orb.Handler.Handler
       Orb.Handler.PermissionAction
       Orb.Handler.PermissionError
+      Orb.HasLogger
       Orb.HasRequest
       Orb.HasRespond
       Orb.Response

--- a/src/Orb.hs
+++ b/src/Orb.hs
@@ -3,6 +3,7 @@ module Orb
   ) where
 
 import Orb.Handler as Export
+import Orb.HasLogger as Export
 import Orb.HasRequest as Export
 import Orb.HasRespond as Export
 import Orb.Response as Export

--- a/src/Orb/Handler/Dispatchable.hs
+++ b/src/Orb/Handler/Dispatchable.hs
@@ -18,6 +18,7 @@ import Shrubbery qualified as S
 import UnliftIO qualified
 
 import Orb.Handler.Handler qualified as Handler
+import Orb.HasLogger qualified as HasLogger
 import Orb.HasRequest qualified as HasRequest
 import Orb.HasRespond qualified as HasRespond
 
@@ -26,7 +27,8 @@ class Dispatchable m a where
 
 instance
   {-# OVERLAPPABLE #-}
-  ( HasRequest.HasRequest m
+  ( HasLogger.HasLogger m
+  , HasRequest.HasRequest m
   , HasRespond.HasRespond m
   , UnliftIO.MonadUnliftIO m
   , Handler.HasHandler route

--- a/src/Orb/HasLogger.hs
+++ b/src/Orb/HasLogger.hs
@@ -1,0 +1,8 @@
+module Orb.HasLogger
+  ( HasLogger (..)
+  ) where
+
+import Control.Exception (SomeException)
+
+class HasLogger m where
+  log :: SomeException -> m ()


### PR DESCRIPTION
This is done using the `HasLogger` type class included in this commit. This gives users a means to define how Orb should log errors in the request handler.