### PR TITLE
Adds Fleece request and response support

### DIFF
--- a/src/Orb/Response/Response.hs
+++ b/src/Orb/Response/Response.hs
@@ -21,6 +21,7 @@ import Control.Monad.IO.Class qualified as MIO
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import Data.Map.Strict qualified as Map
+import Fleece.Core qualified as FC
 import GHC.TypeLits (KnownNat)
 import Network.HTTP.Types qualified as HTTP
 import Network.Wai (Response, ResponseReceived)
@@ -39,9 +40,14 @@ responseBodyList =
   Map.toList . responseStatusMap
 
 data ResponseBody where
-  ResponseContent :: ContentType -> (a -> LBS.ByteString) -> ResponseBody
-  ResponseDocument :: ResponseBody
-  EmptyResponseBody :: ResponseBody
+  ResponseContent ::
+    ContentType -> (body -> LBS.ByteString) -> ResponseBody
+  ResponseSchema ::
+    (forall schema. FC.Fleece schema => schema body) -> ResponseBody
+  ResponseDocument ::
+    ResponseBody
+  EmptyResponseBody ::
+    ResponseBody
 
 data ResponseData = ResponseData
   { responseDataStatus :: HTTP.Status

--- a/src/Orb/Response/StatusCodes.hs
+++ b/src/Orb/Response/StatusCodes.hs
@@ -1382,7 +1382,7 @@ addResponseBody202 ::
 addResponseBody202 =
   addResponseBody @"202"
 
-{- | Appends an HTTP 201 (Accepted) Fleece response to the set of possible
+{- | Appends an HTTP 202 (Accepted) Fleece response to the set of possible
 responses.
 
 /Example usage/:


### PR DESCRIPTION
We've tried to avoid forcing users to use Fleece, but the fact of the matter is that without Fleece, we cannot generate the OpenAPI spec. So, this commit does two things:

1. Adds schema-specific constructors and handlers for `RequestBody` and `ResponseBody`.

2. Adds schema-specific response builder functions. They now use a dedicated function `addResponseSchema` to build them, which itself sets the content type as `application/json`.