### PR TITLE
Exposes `encodeResponse` function

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.1.0
+version:        0.2.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                orb
-version:             0.1.0
+version:             0.2.0
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"

--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -17,6 +17,7 @@ module Orb.Handler.Handler
   , NoRequestBody (..)
   , RequestBody (..)
   , useRouteAsPermissionAction
+  , encodeResponse
   )
 where
 


### PR DESCRIPTION
This allows Orb users to encode the handler response the same as Orb does. This is useful in Middleware and work we are doing with ETags.