### PR TITLE
Adds support for response headers and exposes needed types and functions

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.1.1
+version:        0.1.2
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues

--- a/orb.cabal
+++ b/orb.cabal
@@ -41,6 +41,7 @@ library
       Orb.HasRequest
       Orb.HasRespond
       Orb.Response
+      Orb.Response.AddResponseHeaders
       Orb.Response.ContentType
       Orb.Response.Document
       Orb.Response.HasResponse

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"
 maintainer:          "development@flipstone.com"
-copyright:          "2025 Flipstone Technology Partners, Inc"
+copyright:           "2025 Flipstone Technology Partners, Inc"
 
 language: Haskell2010
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name:                orb
-version:             0.1.1
+version:             0.1.2
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"
 maintainer:          "development@flipstone.com"
-copyright:           "2025 Flipstone Technology Partners, Inc"
+copyright:          "2025 Flipstone Technology Partners, Inc"
 
 language: Haskell2010
 

--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -17,6 +17,7 @@ module Orb.Handler.Handler
   , NoRequestBody (..)
   , RequestBody (..)
   , useRouteAsPermissionAction
+  , encodeResponse
   )
 where
 

--- a/src/Orb/Response.hs
+++ b/src/Orb/Response.hs
@@ -3,6 +3,7 @@ module Orb.Response
   )
 where
 
+import Orb.Response.AddResponseHeaders as Export
 import Orb.Response.ContentType as Export
 import Orb.Response.Document as Export
 import Orb.Response.HasResponse as Export

--- a/src/Orb/Response/AddResponseHeaders.hs
+++ b/src/Orb/Response/AddResponseHeaders.hs
@@ -1,15 +1,17 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
+
 module Orb.Response.AddResponseHeaders
   ( addResponseHeaders
+  , AddResponseHeaderBranches
   ) where
-  
+
 import GHC.TypeLits (KnownNat)
 import Network.HTTP.Types qualified as HTTP
 import Shrubbery (type (@=))
@@ -36,9 +38,8 @@ addResponseHeaders =
 class AddResponseHeaderBranches allResponseCodes someResponseCodes where
   addResponseHeaderBranchBuilder ::
     S.TaggedBranchBuilder
-      someResponseCodes 
+      someResponseCodes
       (HTTP.ResponseHeaders -> S.TaggedUnion allResponseCodes)
-    
 
 instance AddResponseHeaderBranches allResponseCodes '[] where
   addResponseHeaderBranchBuilder =
@@ -53,7 +54,8 @@ instance
   ) =>
   AddResponseHeaderBranches
     allResponseCodes
-    (code @= (returnType, HTTP.ResponseHeaders) : someResponseCodes) where
+    (code @= (returnType, HTTP.ResponseHeaders) : someResponseCodes)
+  where
   addResponseHeaderBranchBuilder =
     S.taggedBranch
       @code
@@ -68,5 +70,3 @@ addHeaders (response, existingHeaders) newHeaders =
   -- newHeaders in put on the front here to avoid rebuilding the linked-list spine
   -- of existingHeaders, which we generally assume will be longer than newHeaders
   (response, newHeaders <> existingHeaders)
-
-

--- a/src/Orb/Response/AddResponseHeaders.hs
+++ b/src/Orb/Response/AddResponseHeaders.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Orb.Response.AddResponseHeaders
+  ( addResponseHeaders
+  ) where
+  
+import GHC.TypeLits (KnownNat)
+import Network.HTTP.Types qualified as HTTP
+import Shrubbery (type (@=))
+import Shrubbery qualified as S
+
+{- |
+Adds extra response headers to a response, typically one produced by a handler
+to be returned for Orb to encode as the response body. This function adds the
+headers without respect to which response body type or status code is tagged on
+the response.
+
+@since 0.1.1
+-}
+addResponseHeaders ::
+  ( AddResponseHeaderBranches responseCodes responseCodes
+  , KnownNat (S.Length (S.TaggedTypes responseCodes))
+  ) =>
+  S.TaggedUnion responseCodes ->
+  HTTP.ResponseHeaders ->
+  S.TaggedUnion responseCodes
+addResponseHeaders =
+  S.dissectTaggedUnion (S.taggedBranchBuild addResponseHeaderBranchBuilder)
+
+class AddResponseHeaderBranches allResponseCodes someResponseCodes where
+  addResponseHeaderBranchBuilder ::
+    S.TaggedBranchBuilder
+      someResponseCodes 
+      (HTTP.ResponseHeaders -> S.TaggedUnion allResponseCodes)
+    
+
+instance AddResponseHeaderBranches allResponseCodes '[] where
+  addResponseHeaderBranchBuilder =
+    S.taggedBranchEnd
+
+instance
+  ( AddResponseHeaderBranches allResponseCodes someResponseCodes
+  , (returnType, HTTP.ResponseHeaders) ~ S.TagType code allResponseCodes
+  , index ~ S.TagIndex code allResponseCodes
+  , (returnType, HTTP.ResponseHeaders) ~ S.TypeAtIndex index (S.TaggedTypes allResponseCodes)
+  , KnownNat index
+  ) =>
+  AddResponseHeaderBranches
+    allResponseCodes
+    (code @= (returnType, HTTP.ResponseHeaders) : someResponseCodes) where
+  addResponseHeaderBranchBuilder =
+    S.taggedBranch
+      @code
+      (\r h -> S.unifyTaggedUnion @code (addHeaders r h))
+      addResponseHeaderBranchBuilder
+
+addHeaders ::
+  (responseType, HTTP.ResponseHeaders) ->
+  HTTP.ResponseHeaders ->
+  (responseType, HTTP.ResponseHeaders)
+addHeaders (response, existingHeaders) newHeaders =
+  -- newHeaders in put on the front here to avoid rebuilding the linked-list spine
+  -- of existingHeaders, which we generally assume will be longer than newHeaders
+  (response, newHeaders <> existingHeaders)
+
+

--- a/src/Orb/Response/AddResponseHeaders.hs
+++ b/src/Orb/Response/AddResponseHeaders.hs
@@ -23,7 +23,7 @@ to be returned for Orb to encode as the response body. This function adds the
 headers without respect to which response body type or status code is tagged on
 the response.
 
-@since 0.1.1
+@since 0.1.2
 -}
 addResponseHeaders ::
   ( AddResponseHeaderBranches responseCodes responseCodes


### PR DESCRIPTION
This PR adds support for adding response headers to the TaggedUnion of responses and in order to use this we needed to expose the class `AddResponseHeaderBranches` as well. 

This exposes the `encodeResponse` function so we can encode and cache the response if needed. 