### PR TITLE
Adds ServerRouter class and helpers

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -37,6 +37,7 @@ library
       Orb.Handler.Handler
       Orb.Handler.PermissionAction
       Orb.Handler.PermissionError
+      Orb.Handler.ServerRouter
       Orb.HasLogger
       Orb.HasRequest
       Orb.HasRespond
@@ -55,6 +56,7 @@ library
       ImportQualifiedPost
   build-depends:
       base >=4.7 && <5
+    , beeline-routing
     , bytestring
     , case-insensitive
     , containers
@@ -84,6 +86,7 @@ test-suite orb-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -O2
   build-depends:
       base >=4.7 && <5
+    , beeline-routing
     , bytestring
     , case-insensitive
     , containers

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ flags:
 
 dependencies:
   - base >= 4.7 && < 5
+  - beeline-routing
   - bytestring
   - case-insensitive
   - containers

--- a/src/Orb/Handler.hs
+++ b/src/Orb/Handler.hs
@@ -8,3 +8,4 @@ import Orb.Handler.Form as Export
 import Orb.Handler.Handler as Export
 import Orb.Handler.PermissionAction as Export
 import Orb.Handler.PermissionError as Export
+import Orb.Handler.ServerRouter as Export

--- a/src/Orb/Handler/ServerRouter.hs
+++ b/src/Orb/Handler/ServerRouter.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Orb.Handler.ServerRouter
+  ( ServerRouter (..)
+  , connect
+  , delete
+  , get
+  , head
+  , options
+  , patch
+  , post
+  , put
+  , trace
+  ) where
+
+import Beeline.Routing qualified as R
+import Network.HTTP.Types qualified as HTTPTypes
+import Prelude hiding (head)
+
+import Orb.Handler.Handler (Handler, HasHandler, routeHandler)
+
+class R.Router r => ServerRouter r where
+  methodHandler ::
+    HTTPTypes.StdMethod ->
+    Handler route ->
+    R.Builder r route route ->
+    r route
+
+instance ServerRouter R.RouteRecognizer where
+  methodHandler stdMethod _handler =
+    R.method stdMethod
+
+connect ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+connect =
+  methodHandler HTTPTypes.CONNECT (routeHandler @route)
+
+delete ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+delete =
+  methodHandler HTTPTypes.DELETE (routeHandler @route)
+
+get ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+get =
+  methodHandler HTTPTypes.GET (routeHandler @route)
+
+head ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+head =
+  methodHandler HTTPTypes.HEAD (routeHandler @route)
+
+options ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+options =
+  methodHandler HTTPTypes.OPTIONS (routeHandler @route)
+
+patch ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+patch =
+  methodHandler HTTPTypes.PATCH (routeHandler @route)
+
+post ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+post =
+  methodHandler HTTPTypes.POST (routeHandler @route)
+
+put ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+put =
+  methodHandler HTTPTypes.PUT (routeHandler @route)
+
+trace ::
+  forall route r.
+  (ServerRouter r, HasHandler route) =>
+  R.Builder r route route ->
+  r route
+trace =
+  methodHandler HTTPTypes.TRACE (routeHandler @route)

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,6 +24,11 @@ packages:
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
 
 extra-deps:
+# Beeline
+- github: flipstone/beeline
+  commit: 319bc02bcdaddcc7f185c74e32c76c5157d51c92
+  subdirs:
+    - beeline-routing
 # Fleece
 - github: flipstone/json-fleece
   commit: 83e675bcb56e86955d0472021ec731e2ebff1ef4

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,6 +5,19 @@
 
 packages:
 - completed:
+    name: beeline-routing
+    pantry-tree:
+      sha256: 4e3af43612d5feacce7c28fa7093c76358d257cf2ce9c5e0321eb6d9888ef195
+      size: 1174
+    sha256: 2e269a7bf5912cfb9bd94fbdcce00322d9e1d872a2e8c7000d6e1adc72833d25
+    size: 24830
+    subdir: beeline-routing
+    url: https://github.com/flipstone/beeline/archive/319bc02bcdaddcc7f185c74e32c76c5157d51c92.tar.gz
+    version: 0.2.4.1
+  original:
+    subdir: beeline-routing
+    url: https://github.com/flipstone/beeline/archive/319bc02bcdaddcc7f185c74e32c76c5157d51c92.tar.gz
+- completed:
     name: json-fleece-aeson
     pantry-tree:
       sha256: 14fc55cbfef5a6751d7168dec038545d05f22e54e28fa310b22b61fad4cfd424


### PR DESCRIPTION
This adds the `ServerRouter` class, a generic abstraction over HTTP method routing for backends using Beeline (a new dependency also added here). It enforces at compile time that each route has a corresponding handler by requiring an instance of `HasHandler`.