### PR TITLE
Adds initial Open API support

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.1.3
+version:        0.1.4
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues
@@ -41,6 +41,8 @@ library
       Orb.HasLogger
       Orb.HasRequest
       Orb.HasRespond
+      Orb.Main
+      Orb.OpenApi
       Orb.Response
       Orb.Response.AddResponseHeaders
       Orb.Response.ContentType
@@ -56,17 +58,27 @@ library
   default-extensions:
       ImportQualifiedPost
   build-depends:
-      base >=4.7 && <5
+      aeson
+    , aeson-pretty
+    , base >=4.7 && <5
     , beeline-routing
     , bytestring
     , case-insensitive
     , containers
+    , hashable
+    , http-media
     , http-types
+    , insert-ordered-containers
     , json-fleece-aeson
     , json-fleece-core
+    , openapi3
+    , optparse-applicative
     , safe-exceptions
+    , semialign
     , shrubbery
     , text
+    , these
+    , unordered-containers
     , wai
     , wai-extra
     , warp
@@ -87,17 +99,32 @@ test-suite orb-test
       ImportQualifiedPost
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -O2
   build-depends:
-      base >=4.7 && <5
+      aeson
+    , aeson-pretty
+    , base >=4.7 && <5
     , beeline-routing
     , bytestring
     , case-insensitive
     , containers
+    , file-embed
+    , hashable
+    , hedgehog
+    , http-media
     , http-types
+    , insert-ordered-containers
     , json-fleece-aeson
     , json-fleece-core
+    , openapi3
+    , optparse-applicative
+    , orb
     , safe-exceptions
+    , semialign
     , shrubbery
+    , tasty
+    , tasty-hedgehog
     , text
+    , these
+    , unordered-containers
     , wai
     , wai-extra
     , warp

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                orb
-version:             0.1.3
+version:             0.1.4
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"
@@ -31,16 +31,26 @@ flags:
 
 dependencies:
   - base >= 4.7 && < 5
+  - aeson
+  - aeson-pretty
   - beeline-routing
   - bytestring
   - case-insensitive
   - containers
+  - hashable
+  - http-media
   - http-types
+  - insert-ordered-containers
   - json-fleece-aeson
   - json-fleece-core
+  - openapi3
+  - optparse-applicative
   - safe-exceptions
+  - semialign
   - shrubbery
+  - these
   - text
+  - unordered-containers
   - wai
   - wai-extra
   - warp
@@ -88,3 +98,11 @@ tests:
       - -Wall
       - -Werror
       - -O2
+    dependencies:
+      - aeson-pretty
+      - beeline-routing
+      - file-embed
+      - hedgehog
+      - orb
+      - tasty
+      - tasty-hedgehog

--- a/src/Orb.hs
+++ b/src/Orb.hs
@@ -6,5 +6,7 @@ import Orb.Handler as Export
 import Orb.HasLogger as Export
 import Orb.HasRequest as Export
 import Orb.HasRespond as Export
+import Orb.Main as Export
+import Orb.OpenApi as Export
 import Orb.Response as Export
 import Orb.Wai as Export

--- a/src/Orb/Main.hs
+++ b/src/Orb/Main.hs
@@ -1,0 +1,121 @@
+module Orb.Main
+  ( main
+  , mainParserInfo
+  , mainParser
+  , mainParserWithCommands
+  , openApiLabelArgument
+  , generateOpenApiCommand
+  , generateOpenApiMain
+  ) where
+
+import Data.Aeson.Encode.Pretty qualified as AesonPretty
+import Data.ByteString.Lazy qualified as LBS
+import Data.List qualified as List
+import Options.Applicative qualified as Opt
+import System.Exit qualified as Exit
+import System.IO qualified as IO
+
+import Orb.OpenApi qualified as OpenApi
+
+{- |
+  Constructs a main function that parses the command line arguments and
+  provides two subcommands in the executable:
+
+  - @api@ - runs the IO action provided as the main. Presumably this
+    invokes some form of 'Orb.Wai.runOrb' (or otherwise runs a way server)
+    that serves an application handling the routes provided to this function.
+
+  - @generate-open-api@ - accepts a argument matching one of the labels
+    provided to 'OpenApi.provideOpenApi' and prints an OpenApi description
+    of the labeled routes as JSON to stdout.
+-}
+main :: OpenApi.OpenApiRouter a -> IO () -> IO ()
+main routes appMain = do
+  io <- Opt.customExecParser parserPrefs (mainParserInfo appMain routes)
+  io
+
+{- |
+  Constructs a 'Opt.ParserInfo' that will execute as description in 'main', but
+  can be used as an argument to 'Opt.command' to use it as a subcommand.
+-}
+mainParserInfo :: IO () -> OpenApi.OpenApiRouter a -> Opt.ParserInfo (IO ())
+mainParserInfo apiMain routes =
+  Opt.info (mainParser apiMain routes) mempty
+
+{- |
+  Constructs a 'Opt.Parser' that will execute as description in 'main', but
+  can be used directly in other option parsers.
+-}
+mainParser :: IO () -> OpenApi.OpenApiRouter a -> Opt.Parser (IO ())
+mainParser apiMain =
+  mainParserWithCommands
+    [ Opt.command "api" (Opt.info (pure apiMain) mempty)
+    ]
+
+{- |
+  Constructs an 'Opt.Parser' than has the @generate-open-api@ command as in
+  the 'main' function along with the other commands passed. In this case no
+  @api@ command is added by orb. It is up to the application to passed
+  whatever set of other commands it desires.
+-}
+mainParserWithCommands ::
+  [Opt.Mod Opt.CommandFields (IO ())] ->
+  OpenApi.OpenApiRouter a ->
+  Opt.Parser (IO ())
+mainParserWithCommands commands routes =
+  Opt.hsubparser $
+    mconcat
+      ( generateOpenApiCommand routes
+          : commands
+      )
+
+{- |
+  Constructs an 'Opt.command' modifier for the @generate-open-api@ command that
+  can be used along with 'Opt.hsubparser' include the command wherever the user
+  chooses in their options parsing.
+-}
+generateOpenApiCommand :: OpenApi.OpenApiRouter a -> Opt.Mod Opt.CommandFields (IO ())
+generateOpenApiCommand routes =
+  Opt.command "generate-open-api" (Opt.info (generateOpenApiMain routes <$> openApiLabelArgument routes) mempty)
+
+{- |
+  Constructs a 'Opt.Parser' than will parse an argument representing one
+  of the sections of the provided router that have been labeled via
+  'OpenApi.provideOpenApi'. The available labels in the router will be
+  used to provide autocomplete as well as included in the programs help
+  text.
+-}
+openApiLabelArgument :: OpenApi.OpenApiRouter a -> Opt.Parser String
+openApiLabelArgument routes =
+  let
+    labels = OpenApi.openApiLabels routes
+  in
+    Opt.strArgument
+      ( Opt.metavar "LABEL"
+          <> Opt.completeWith labels
+          <> Opt.help ("labels: " <> List.intercalate "," labels)
+      )
+
+parserPrefs :: Opt.ParserPrefs
+parserPrefs =
+  Opt.prefs $ Opt.showHelpOnEmpty <> Opt.showHelpOnError
+
+{- |
+  A main function that prints requested the OpenApi spec from the given
+  router to @stdout@ as JSON. If no matching spec is found or if an error
+  occurs while generating it, the error will be reported to @stderr@ and
+  the process will exit with status code @1@.
+
+  This is intended for users who want to include the functionality of
+  the @generate-open-api@ command in their own main functions without
+  using @optparse-applicative@.
+-}
+generateOpenApiMain :: OpenApi.OpenApiRouter a -> String -> IO ()
+generateOpenApiMain routes label =
+  case OpenApi.mkOpenApi routes label of
+    Left err -> do
+      IO.hPutStrLn IO.stderr ("Unable to generate OpenApi Spec for " <> label <> "!")
+      IO.hPutStrLn IO.stderr err
+      Exit.exitWith (Exit.ExitFailure 1)
+    Right openApi ->
+      LBS.putStr (AesonPretty.encodePretty openApi)

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -1,0 +1,948 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Orb.OpenApi
+  ( mkOpenApi
+  , openApiLabels
+  , OpenApiProvider (provideOpenApi)
+  , OpenApiRouter
+  , FleeceOpenApi
+  , SchemaWithComponents (..)
+  , schemaWithComponents
+  ) where
+
+import Beeline.Routing qualified as R
+import Control.Monad qualified as Monad
+import Data.Aeson qualified as Aeson
+import Data.Align qualified as Align
+import Data.ByteString.Char8 qualified as BS8
+import Data.HashMap.Strict.InsOrd qualified as IOHM
+import Data.Hashable (Hashable)
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
+import Data.Maybe qualified as Maybe
+import Data.OpenApi qualified as OpenApi
+import Data.Text qualified as T
+import Data.These qualified as These
+import Fleece.Core qualified as FC
+import GHC.TypeLits (symbolVal)
+import Network.HTTP.Media.MediaType qualified as MediaType
+import Network.HTTP.Types qualified as HTTPTypes
+
+import Orb.Handler qualified as Handler
+import Orb.Response qualified as Response
+
+{- |
+  This class represents routers that can be used to provide OpenApi
+  descriptions of parts of their routes.
+-}
+class Handler.ServerRouter r => OpenApiProvider r where
+  -- |
+  --     Labels the provided router with a user-defined string that can be
+  --     passed later to 'mkOpenApi' to retrieve the OpenApi description for
+  --     that part of the api. If multiple sections are labeled with the
+  --     same label, their definitions will be combined to provide a single
+  --     OpenApi description.
+  provideOpenApi :: String -> r a -> r a
+
+instance OpenApiProvider R.RouteRecognizer where
+  provideOpenApi _label = id
+
+{- |
+  Retrieves the list of all labels that were passed to 'provideOpenApi'
+  within the given router.
+-}
+openApiLabels :: OpenApiRouter a -> [String]
+openApiLabels (OpenApiRouter builders) =
+  Map.keys (labeledBuilders builders)
+
+{- |
+  Returns the 'OpenApi.OpenApi' descriptions for the api section that was
+  labeled with the provide label via the 'provideOpenApi' function. If
+  no section with the label can be found or if an error occurs while generating
+  the OpenApi description, an error will be returned.
+-}
+mkOpenApi :: OpenApiRouter a -> String -> Either String OpenApi.OpenApi
+mkOpenApi (OpenApiRouter builders) label = do
+  builder <-
+    case Map.lookup label (labeledBuilders builders) of
+      Nothing -> Left ("No OpenApi definition found with label " <> label <> ".")
+      Just builder -> Right builder
+
+  apiInfo <-
+    runOpenApiBuilder builder $
+      PathInfo
+        { pathInfoPath = ""
+        , pathInfoParams = []
+        }
+
+  let
+    paths =
+      toIOHM . apiPaths $ apiInfo
+
+    componentsSchemas =
+      toIOHM
+        . fmap openApiSchema
+        . apiSchemaComponents
+        $ apiInfo
+
+  pure $
+    mempty
+      { OpenApi._openApiPaths = paths
+      , OpenApi._openApiComponents =
+          mempty
+            { OpenApi._componentsSchemas = componentsSchemas
+            }
+      }
+
+toIOHM :: Hashable k => Map.Map k v -> IOHM.InsOrdHashMap k v
+toIOHM =
+  IOHM.fromList . Map.toList
+
+data ApiInfo = ApiInfo
+  { apiPaths :: Map.Map FilePath OpenApi.PathItem
+  , apiSchemaComponents :: Map.Map T.Text SchemaInfo
+  }
+
+emptyApiInfo :: ApiInfo
+emptyApiInfo =
+  ApiInfo
+    { apiPaths = Map.empty
+    , apiSchemaComponents = Map.empty
+    }
+
+combineApiInfo :: ApiInfo -> ApiInfo -> Either String ApiInfo
+combineApiInfo left right = do
+  components <-
+    combineSchemaComponents
+      (apiSchemaComponents left)
+      (apiSchemaComponents right)
+  pure $
+    ApiInfo
+      { apiPaths =
+          Map.unionWith combinePathItems (apiPaths left) (apiPaths right)
+      , apiSchemaComponents = components
+      }
+
+{- |
+  The Semigroup instance of 'OpenApi.PathItem' concatenates all the parameters
+  from both path items. Since by definition these items were at the same path,
+  they should all have generated the same parameters from the Beeline route so
+  we arbitrary pick just the left params instead.
+-}
+combinePathItems :: OpenApi.PathItem -> OpenApi.PathItem -> OpenApi.PathItem
+combinePathItems left right =
+  (left <> right)
+    { OpenApi._pathItemParameters = OpenApi._pathItemParameters left
+    }
+
+combineSchemaComponents ::
+  Map.Map T.Text SchemaInfo ->
+  Map.Map T.Text SchemaInfo ->
+  Either String (Map.Map T.Text SchemaInfo)
+combineSchemaComponents left right =
+  let
+    checkForConflict theseSchemas =
+      case theseSchemas of
+        These.This this -> Right this
+        These.That that -> Right that
+        These.These this that ->
+          if this == that
+            then Right this
+            else
+              Left $
+                "Conflicting schema definitions found "
+                  <> FC.nameToString (fleeceName this)
+                  <> " and "
+                  <> FC.nameToString (fleeceName that)
+
+    addKeyToError :: T.Text -> Either String a -> Either String a
+    addKeyToError key errOrSchemaInfo =
+      case errOrSchemaInfo of
+        Left err -> Left (T.unpack key <> ": " <> err)
+        Right schemaInfo -> Right schemaInfo
+  in
+    Map.traverseWithKey
+      addKeyToError
+      (Align.alignWith checkForConflict left right)
+
+singletonApiInfo ::
+  Map.Map T.Text SchemaInfo ->
+  PathInfo ->
+  OpenApi.PathItem ->
+  ApiInfo
+singletonApiInfo components pathInfo pathItem =
+  ApiInfo
+    { apiPaths = Map.singleton (pathInfoPath pathInfo) pathItem
+    , apiSchemaComponents = components
+    }
+
+newtype OpenApiBuilder
+  = OpenApiBuilder (PathInfo -> Either String ApiInfo)
+
+runOpenApiBuilder :: OpenApiBuilder -> PathInfo -> Either String ApiInfo
+runOpenApiBuilder (OpenApiBuilder f) =
+  f
+
+modifyOpenApiBuilderPathInfo ::
+  (PathInfo -> PathInfo) ->
+  OpenApiBuilder ->
+  OpenApiBuilder
+modifyOpenApiBuilderPathInfo f (OpenApiBuilder mkApiInfo) =
+  OpenApiBuilder $ \pathInfo -> mkApiInfo (f pathInfo)
+
+emptyOpenApiBuilder :: OpenApiBuilder
+emptyOpenApiBuilder =
+  OpenApiBuilder (const (Right emptyApiInfo))
+
+combineOpenApiBuilder ::
+  OpenApiBuilder ->
+  OpenApiBuilder ->
+  OpenApiBuilder
+combineOpenApiBuilder (OpenApiBuilder left) (OpenApiBuilder right) =
+  OpenApiBuilder $ \parentContext ->
+    Monad.join $
+      liftA2
+        combineApiInfo
+        (left parentContext)
+        (right parentContext)
+
+data OpenApiBuilders = OpenApiBuilders
+  { labeledBuilders :: Map.Map String OpenApiBuilder
+  , unlabeledBuilder :: OpenApiBuilder
+  }
+
+emptyOpenApiBuilders :: OpenApiBuilders
+emptyOpenApiBuilders =
+  OpenApiBuilders
+    { labeledBuilders = Map.empty
+    , unlabeledBuilder = emptyOpenApiBuilder
+    }
+
+modifyOpenApiBuildersPathInfo ::
+  (PathInfo -> PathInfo) ->
+  OpenApiBuilders ->
+  OpenApiBuilders
+modifyOpenApiBuildersPathInfo f builders =
+  OpenApiBuilders
+    { labeledBuilders = modifyOpenApiBuilderPathInfo f <$> labeledBuilders builders
+    , unlabeledBuilder = modifyOpenApiBuilderPathInfo f (unlabeledBuilder builders)
+    }
+
+combineOpenApiBuilders ::
+  OpenApiBuilders ->
+  OpenApiBuilders ->
+  OpenApiBuilders
+combineOpenApiBuilders left right =
+  OpenApiBuilders
+    { labeledBuilders =
+        Map.unionWith
+          combineOpenApiBuilder
+          (labeledBuilders left)
+          (labeledBuilders right)
+    , unlabeledBuilder =
+        combineOpenApiBuilder
+          (unlabeledBuilder left)
+          (unlabeledBuilder right)
+    }
+
+{- |
+  A concrete type that implements the beeline and Orb router classes and
+  can be used with 'mkOpenApi'.
+-}
+newtype OpenApiRouter a
+  = OpenApiRouter OpenApiBuilders
+
+instance OpenApiProvider OpenApiRouter where
+  provideOpenApi name (OpenApiRouter builders) =
+    let
+      additionalBuilders =
+        emptyOpenApiBuilders
+          { labeledBuilders =
+              Map.singleton name (unlabeledBuilder builders)
+          }
+    in
+      OpenApiRouter $
+        combineOpenApiBuilders additionalBuilders builders
+
+instance Handler.ServerRouter OpenApiRouter where
+  methodHandler method handler (Builder mkRoute) =
+    let
+      builder =
+        OpenApiBuilder $ \parentContext -> do
+          mbRequestBody <- mkRequestBody handler
+
+          let
+            (mbReqBody, reqComponents) =
+              case mbRequestBody of
+                Nothing -> (Nothing, Map.empty)
+                Just (reqBody, reqComps) -> (Just reqBody, reqComps)
+
+          (responses, responseComponents) <- mkResponses handler
+          allComponents <- combineSchemaComponents reqComponents responseComponents
+
+          let
+            operation =
+              mempty
+                { OpenApi._operationOperationId = Just . T.pack . Handler.handlerId $ handler
+                , OpenApi._operationRequestBody = mbReqBody
+                , OpenApi._operationResponses = responses
+                }
+
+            pathInfo =
+              mkRoute parentContext
+
+            mbPathItem =
+              mkPathItem method pathInfo operation
+
+          case mbPathItem of
+            Nothing ->
+              Left $
+                "Unable to create OpenAPI for description of "
+                  <> pathInfoPath pathInfo
+                  <> " due to use of HTTP Method: "
+                  <> BS8.unpack (HTTPTypes.renderStdMethod method)
+            Just pathItem -> do
+              pure $ singletonApiInfo allComponents pathInfo pathItem
+    in
+      OpenApiRouter $
+        emptyOpenApiBuilders
+          { unlabeledBuilder = builder
+          }
+
+data PathInfo = PathInfo
+  { pathInfoPath :: FilePath
+  , pathInfoParams :: [OpenApi.Param]
+  }
+
+addPathPiece :: PathInfo -> String -> PathInfo
+addPathPiece pathInfo piece =
+  pathInfo
+    { pathInfoPath = pathInfoPath pathInfo <> "/" <> piece
+    }
+
+addPathParam :: PathInfo -> OpenApi.Param -> PathInfo
+addPathParam pathInfo param =
+  pathInfo
+    { pathInfoPath =
+        pathInfoPath pathInfo
+          <> "/{"
+          <> T.unpack (OpenApi._paramName param)
+          <> "}"
+    , pathInfoParams =
+        pathInfoParams pathInfo <> [param]
+    }
+
+instance R.Router OpenApiRouter where
+  newtype RouteList OpenApiRouter _subRoutes
+    = RouteList OpenApiBuilders
+
+  newtype Builder OpenApiRouter _router _a
+    = Builder (PathInfo -> PathInfo)
+
+  make _route =
+    Builder id
+
+  piece (Builder mkRoute) pathPiece =
+    Builder $ \parentContext ->
+      addPathPiece (mkRoute parentContext) (T.unpack pathPiece)
+
+  param (Builder mkRoute) param =
+    Builder $ \parentContext ->
+      addPathParam
+        (mkRoute parentContext)
+        (mkOpenApiPathParam (R.paramDefinition param))
+
+  method method (Builder mkRoute) =
+    let
+      builder =
+        OpenApiBuilder $
+          \parentContext ->
+            let
+              pathInfo =
+                mkRoute parentContext
+            in
+              Left
+                ( "Unable to make OpenAPI description for router defined using standard Beeline 'method' (or helpers such as 'get'): "
+                    <> BS8.unpack (HTTPTypes.renderStdMethod method)
+                    <> " "
+                    <> pathInfoPath pathInfo
+                )
+    in
+      OpenApiRouter $
+        emptyOpenApiBuilders
+          { unlabeledBuilder = builder
+          }
+
+  subrouter (Builder mkRoute) subrouter =
+    OpenApiRouter $
+      let
+        (OpenApiRouter openApiBuilders) =
+          R.subrouteRouter subrouter
+      in
+        modifyOpenApiBuildersPathInfo mkRoute openApiBuilders
+
+  routeList (RouteList mkRoutes) =
+    OpenApiRouter mkRoutes
+
+  addRoute (OpenApiRouter routerBuilders) (RouteList listBuilders) =
+    RouteList (combineOpenApiBuilders routerBuilders listBuilders)
+
+  emptyRoutes =
+    RouteList emptyOpenApiBuilders
+
+mkPathItem ::
+  HTTPTypes.StdMethod ->
+  PathInfo ->
+  OpenApi.Operation ->
+  Maybe OpenApi.PathItem
+mkPathItem method pathInfo operation =
+  let
+    baseItem =
+      mempty
+        { OpenApi._pathItemParameters =
+            fmap OpenApi.Inline (pathInfoParams pathInfo)
+        }
+  in
+    case method of
+      HTTPTypes.GET -> Just $ baseItem {OpenApi._pathItemGet = Just operation}
+      HTTPTypes.POST -> Just $ baseItem {OpenApi._pathItemPost = Just operation}
+      HTTPTypes.PUT -> Just $ baseItem {OpenApi._pathItemPut = Just operation}
+      HTTPTypes.HEAD -> Just $ baseItem {OpenApi._pathItemHead = Just operation}
+      HTTPTypes.DELETE -> Just $ baseItem {OpenApi._pathItemDelete = Just operation}
+      HTTPTypes.TRACE -> Just $ baseItem {OpenApi._pathItemTrace = Just operation}
+      HTTPTypes.OPTIONS -> Just $ baseItem {OpenApi._pathItemOptions = Just operation}
+      HTTPTypes.PATCH -> Just $ baseItem {OpenApi._pathItemPatch = Just operation}
+      HTTPTypes.CONNECT -> Nothing
+
+mkRequestBody ::
+  Handler.Handler route ->
+  Either String (Maybe (OpenApi.Referenced OpenApi.RequestBody, Map.Map T.Text SchemaInfo))
+mkRequestBody handler =
+  case Handler.requestBody handler of
+    Handler.RequestSchema (FleeceOpenApi errOrSchemaInfo) -> do
+      schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
+
+      let
+        schemaRef =
+          mkSchemaRef schemaInfo
+
+        mediaTypeObject =
+          mempty
+            { OpenApi._mediaTypeObjectSchema = Just schemaRef
+            }
+
+        requestBody =
+          OpenApi.Inline $
+            OpenApi.RequestBody
+              { OpenApi._requestBodyDescription = Nothing
+              , OpenApi._requestBodyRequired = Just True
+              , OpenApi._requestBodyContent =
+                  IOHM.fromList
+                    [ (mkMediaType "application" "json", mediaTypeObject)
+                    ]
+              }
+
+      components <- collectComponents [schemaInfo]
+      pure $ Just (requestBody, components)
+    Handler.RequestRawBody _decoder ->
+      Right Nothing
+    Handler.RequestFormData _formDecoder ->
+      Right Nothing
+    Handler.EmptyRequestBody ->
+      Right Nothing
+
+mkResponses ::
+  Handler.Handler router ->
+  Either String (OpenApi.Responses, Map.Map T.Text SchemaInfo)
+mkResponses handler =
+  let
+    schemas =
+      Response.responseBodyList . Handler.handlerResponseBodies $ handler
+
+    addResponse (responses, components) (status, responseSchema) = do
+      mbSchemaInfo <-
+        case responseSchema of
+          Response.ResponseContent _contentType _encoder -> pure Nothing
+          Response.ResponseSchema (FleeceOpenApi info) -> fmap Just info
+          Response.ResponseDocument -> pure Nothing
+          Response.EmptyResponseBody -> pure Nothing
+      let
+        mkResponseContent schemaRef =
+          IOHM.fromList
+            [ (mkMediaType "application" "json", mempty {OpenApi._mediaTypeObjectSchema = Just schemaRef})
+            ]
+
+        mbResponseContent =
+          fmap (mkResponseContent . mkSchemaRef) mbSchemaInfo
+
+        response =
+          OpenApi.Inline $
+            OpenApi.Response
+              { OpenApi._responseDescription = T.empty
+              , OpenApi._responseContent = Maybe.fromMaybe mempty mbResponseContent
+              , OpenApi._responseHeaders = IOHM.empty
+              , OpenApi._responseLinks = IOHM.empty
+              }
+
+        newResponses =
+          responses
+            { OpenApi._responsesResponses =
+                IOHM.insert
+                  (HTTPTypes.statusCode status)
+                  response
+                  (OpenApi._responsesResponses responses)
+            }
+
+      newComponents <-
+        combineSchemaComponents components =<< collectComponents (Maybe.maybeToList mbSchemaInfo)
+
+      pure (newResponses, newComponents)
+  in
+    Monad.foldM addResponse (mempty, Map.empty) schemas
+
+mkMediaType :: String -> String -> MediaType.MediaType
+mkMediaType main sub =
+  (MediaType.//) (BS8.pack main) (BS8.pack sub)
+
+mkProperties :: [FieldInfo] -> IOHM.InsOrdHashMap T.Text (OpenApi.Referenced OpenApi.Schema)
+mkProperties =
+  let
+    mkEntry fieldInfo =
+      (fieldName fieldInfo, mkSchemaRef (fieldSchemaInfo fieldInfo))
+  in
+    IOHM.fromList . fmap mkEntry
+
+mkRequiredProperties :: [FieldInfo] -> [OpenApi.ParamName]
+mkRequiredProperties =
+  fmap fieldName
+    . List.filter fieldRequired
+
+mkOpenApiPathParam :: R.ParameterDefinition a -> OpenApi.Param
+mkOpenApiPathParam param =
+  mempty
+    { OpenApi._paramName = R.parameterName param
+    , OpenApi._paramIn = OpenApi.ParamPath
+    , OpenApi._paramRequired = Just True
+    , OpenApi._paramSchema =
+        Just
+          . OpenApi.Inline
+          $ mempty
+            { OpenApi._schemaType = Just OpenApi.OpenApiString
+            }
+    }
+
+{- |
+  A concrete type that implements the Fleece typeclasses to build an
+  OpenApi description of the JSON describe by the Fleece schema definition.
+  Can be used with 'schemaWithComponents' to retrieve the 'OpenApi.Schema'
+  description of the schema.
+-}
+newtype FleeceOpenApi a = FleeceOpenApi
+  { unFleeceOpenApi :: Either String SchemaInfo
+  }
+
+{- |
+  An 'OpenApi.Schema' pair with any other component schemas that it is
+  dependent on. This can be construction from a Fleece JSON schema via the
+  'schemaWithComponents' function.
+-}
+data SchemaWithComponents = SchemaWithComponents
+  { schemaWithComponentsSchema :: OpenApi.Schema
+  , schemaWithComponentsComponents :: IOHM.InsOrdHashMap T.Text OpenApi.Schema
+  }
+
+{- |
+  Constructions a 'SchemaWithComponents' OpenApi description of the provided
+  Fleece schema. If an error occurs during construction (e.g. conflicting
+  definitions of the same component), an error will be returned.
+-}
+schemaWithComponents :: FleeceOpenApi a -> Either String SchemaWithComponents
+schemaWithComponents =
+  fmap
+    ( \schemaInfo ->
+        SchemaWithComponents
+          { schemaWithComponentsSchema = openApiSchema schemaInfo
+          , schemaWithComponentsComponents =
+              Map.foldMapWithKey
+                (\key -> IOHM.singleton key . openApiSchema)
+                (schemaComponents schemaInfo)
+          }
+    )
+    . unFleeceOpenApi
+
+data SchemaInfo = SchemaInfo
+  { fleeceName :: FC.Name
+  , schemaIsPrimitive :: Bool
+  , openApiKey :: Maybe T.Text
+  , openApiSchema :: OpenApi.Schema
+  , schemaComponents :: Map.Map T.Text SchemaInfo
+  }
+  deriving (Eq)
+
+setSchemaInfoFormat :: T.Text -> SchemaInfo -> SchemaInfo
+setSchemaInfoFormat fmt info =
+  info
+    { openApiSchema =
+        (openApiSchema info)
+          { OpenApi._schemaFormat = Just fmt
+          }
+    }
+
+collectComponents :: [SchemaInfo] -> Either String (Map.Map T.Text SchemaInfo)
+collectComponents schemaInfos =
+  let
+    mkTopLevel schemaInfo =
+      case openApiKey schemaInfo of
+        Nothing -> Map.empty
+        Just key -> Map.singleton key schemaInfo
+
+    topLevels =
+      fmap mkTopLevel schemaInfos
+
+    descendants =
+      fmap schemaComponents schemaInfos
+  in
+    Monad.foldM
+      combineSchemaComponents
+      Map.empty
+      (topLevels <> descendants)
+
+mkSchemaRef ::
+  SchemaInfo ->
+  OpenApi.Referenced OpenApi.Schema
+mkSchemaRef schema =
+  case openApiKey schema of
+    Just schemaKey ->
+      OpenApi.Ref . OpenApi.Reference $ schemaKey
+    Nothing ->
+      OpenApi.Inline . openApiSchema $ schema
+
+mkPrimitiveSchema ::
+  String ->
+  OpenApi.OpenApiType ->
+  SchemaInfo
+mkPrimitiveSchema name openApiType =
+  SchemaInfo
+    { fleeceName = FC.unqualifiedName name
+    , schemaIsPrimitive = True
+    , openApiKey = Nothing
+    , openApiSchema =
+        mempty
+          { OpenApi._schemaType = Just openApiType
+          }
+    , schemaComponents = Map.empty
+    }
+
+data FieldInfo = FieldInfo
+  { fieldName :: T.Text
+  , fieldRequired :: Bool
+  , fieldSchemaInfo :: SchemaInfo
+  }
+
+instance FC.Fleece FleeceOpenApi where
+  data Object FleeceOpenApi _object _constructor
+    = Object (Either String [FieldInfo])
+
+  data Field FleeceOpenApi _object _field
+    = Field (Either String FieldInfo)
+
+  data AdditionalFields FleeceOpenApi _object _field
+    = AdditionalFields
+
+  data UnionMembers FleeceOpenApi _allTypes _handledTypes
+    = UnionMembers (Either String [SchemaInfo])
+
+  data TaggedUnionMembers FleeceOpenApi _allTags _handledTags
+    = TaggedUnionMembers (FieldInfo -> String -> Either String [(T.Text, SchemaInfo)])
+
+  schemaName (FleeceOpenApi errOrSchemaInfo) =
+    case errOrSchemaInfo of
+      Left err -> FC.unqualifiedName ("Unable to get schema name:" <> err)
+      Right schemaInfo -> fleeceName schemaInfo
+
+  number =
+    FleeceOpenApi . Right $ mkPrimitiveSchema "number" OpenApi.OpenApiNumber
+
+  text =
+    FleeceOpenApi . Right $ mkPrimitiveSchema "text" OpenApi.OpenApiString
+
+  boolean =
+    FleeceOpenApi . Right $ mkPrimitiveSchema "boolean" OpenApi.OpenApiBoolean
+
+  null =
+    FleeceOpenApi . Right $ mkPrimitiveSchema "null" OpenApi.OpenApiNull
+
+  array (FleeceOpenApi errOrItemSchemaInfo) =
+    FleeceOpenApi $ do
+      itemSchemaInfo <- errOrItemSchemaInfo
+      components <- collectComponents [itemSchemaInfo]
+
+      let
+        itemSchemaRef =
+          mkSchemaRef itemSchemaInfo
+
+      pure $
+        SchemaInfo
+          { fleeceName = FC.annotateName (fleeceName itemSchemaInfo) "array"
+          , schemaIsPrimitive = False
+          , openApiKey = Nothing
+          , openApiSchema =
+              mempty
+                { OpenApi._schemaType = Just OpenApi.OpenApiArray
+                , OpenApi._schemaItems = Just (OpenApi.OpenApiItemsObject itemSchemaRef)
+                }
+          , schemaComponents = components
+          }
+
+  nullable (FleeceOpenApi errOrSchemaInfo) =
+    FleeceOpenApi $ do
+      schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
+      components <- collectComponents [schemaInfo]
+
+      pure $
+        SchemaInfo
+          { fleeceName = FC.annotateName (fleeceName schemaInfo) "nullable"
+          , schemaIsPrimitive = schemaIsPrimitive schemaInfo
+          , openApiKey = Nothing
+          , openApiSchema =
+              (openApiSchema schemaInfo)
+                { OpenApi._schemaNullable = Just True
+                }
+          , schemaComponents = components
+          }
+
+  required name _accessor (FleeceOpenApi errOrSchemaInfo) =
+    Field $ do
+      schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
+      pure $
+        FieldInfo
+          { fieldName = T.pack name
+          , fieldRequired = True
+          , fieldSchemaInfo = schemaInfo
+          }
+
+  optional name _accessor (FleeceOpenApi errOrSchemaInfo) =
+    Field $ do
+      schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
+      pure $
+        FieldInfo
+          { fieldName = T.pack name
+          , fieldRequired = False
+          , fieldSchemaInfo = schemaInfo
+          }
+
+  mapField _f (Field fieldInfo) =
+    Field fieldInfo
+
+  additionalFields _accessor _schema =
+    AdditionalFields
+
+  objectNamed name (Object errOrFieldsInReverse) =
+    FleeceOpenApi (mkObjectForFields name =<< errOrFieldsInReverse)
+
+  constructor _cons =
+    Object (Right [])
+
+  field (Object fieldInfos) (Field newFieldInfo) =
+    Object (liftA2 (:) newFieldInfo fieldInfos)
+
+  additional (Object _fields) _additional =
+    Object (Left "Fleece additional fields not currently support for OpenAPI")
+
+  validateNamed name _uncheck _check (FleeceOpenApi errOrSchemaInfo) = do
+    FleeceOpenApi $ do
+      schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
+
+      if schemaIsPrimitive schemaInfo
+        then do
+          components <- collectComponents [schemaInfo]
+          pure $
+            schemaInfo
+              { fleeceName = name
+              , openApiKey = Just . fleeceNameToOpenApiKey $ name
+              , schemaComponents = components
+              }
+        else pure schemaInfo
+
+  boundedEnumNamed name toText =
+    let
+      enumValues =
+        fmap
+          (Aeson.toJSON . toText)
+          [minBound .. maxBound]
+    in
+      FleeceOpenApi
+        . Right
+        $ SchemaInfo
+          { fleeceName = name
+          , schemaIsPrimitive = False
+          , openApiKey = Just . fleeceNameToOpenApiKey $ name
+          , openApiSchema =
+              mempty
+                { OpenApi._schemaType = Just OpenApi.OpenApiString
+                , OpenApi._schemaEnum = Just enumValues
+                }
+          , schemaComponents = Map.empty
+          }
+
+  unionNamed name (UnionMembers _members) =
+    FleeceOpenApi
+      . Left
+      $ "Fleece unions are not currently implemented for OpenApi: " <> FC.nameToString name
+
+  unionMemberWithIndex _idx (FleeceOpenApi _schemaInfo) =
+    UnionMembers
+      . Left
+      $ "Fleece unions are not currently implemented for OpenApi"
+
+  unionCombine (UnionMembers _left) (UnionMembers _right) =
+    UnionMembers
+      . Left
+      $ "Fleece unions are not currently implemented for OpenApi"
+
+  taggedUnionNamed name tagPropertyString (TaggedUnionMembers mkMembers) =
+    FleeceOpenApi $ do
+      let
+        tagProperty =
+          T.pack tagPropertyString
+
+        memberKeyPrefix =
+          FC.nameUnqualified name <> "."
+
+        FleeceOpenApi errOrStringSchema =
+          FC.text
+
+        mkTagField tagSchema =
+          FieldInfo
+            { fieldName = tagProperty
+            , fieldRequired = True
+            , fieldSchemaInfo = tagSchema
+            }
+
+        mkMappingEntry (tagValue, schemaInfo) =
+          case openApiKey schemaInfo of
+            Just key -> Right (tagValue, componentsPrefix <> key)
+            Nothing ->
+              Left $
+                "No Schema Key found for member "
+                  <> T.unpack tagValue
+                  <> " of union "
+                  <> FC.nameToString name
+
+      stringSchema <- errOrStringSchema
+      members <- mkMembers (mkTagField stringSchema) memberKeyPrefix
+
+      components <- collectComponents (fmap snd members)
+
+      mappingEntries <- traverse mkMappingEntry members
+
+      let
+        discriminator =
+          OpenApi.Discriminator
+            { OpenApi._discriminatorPropertyName = tagProperty
+            , OpenApi._discriminatorMapping = IOHM.fromList mappingEntries
+            }
+
+        memberSchemaRefs =
+          fmap (mkSchemaRef . snd) members
+
+        key =
+          Just $ fleeceNameToOpenApiKey name
+
+      pure $
+        SchemaInfo
+          { fleeceName = name
+          , schemaIsPrimitive = False
+          , openApiKey = key
+          , openApiSchema =
+              mempty
+                { OpenApi._schemaType = Nothing
+                , OpenApi._schemaDiscriminator = Just discriminator
+                , OpenApi._schemaOneOf = Just memberSchemaRefs
+                , OpenApi._schemaTitle = key
+                }
+          , schemaComponents = components
+          }
+
+  taggedUnionMemberWithTag tag (Object errOrFieldsInReverse) =
+    TaggedUnionMembers $ \tagField memberKeyPrefix -> do
+      let
+        tagValue =
+          symbolVal tag
+
+        -- TODO: come up with better name
+        memberName =
+          FC.unqualifiedName (memberKeyPrefix <> tagValue)
+
+      -- TODO: add tag property to schema
+      fieldsInReverse <- errOrFieldsInReverse
+
+      let
+        fieldsInReverseWithTag =
+          fieldsInReverse <> [tagField]
+
+      objectSchema <- mkObjectForFields memberName fieldsInReverseWithTag
+
+      pure [(T.pack tagValue, objectSchema)]
+
+  taggedUnionCombine (TaggedUnionMembers mkLeft) (TaggedUnionMembers mkRight) =
+    TaggedUnionMembers $ \tagProperty memberKeyPrefix -> do
+      left <- mkLeft tagProperty memberKeyPrefix
+      right <- mkRight tagProperty memberKeyPrefix
+      pure (left <> right)
+
+  jsonString (FleeceOpenApi _schemaInfo) =
+    FleeceOpenApi
+      . Left
+      $ "Fleece jsonString is not currently implemented for OpenApi"
+
+mkObjectForFields ::
+  FC.Name ->
+  [FieldInfo] ->
+  Either String SchemaInfo
+mkObjectForFields name fieldsInReverse = do
+  let
+    key =
+      Just $ fleeceNameToOpenApiKey name
+    fieldsInOrder =
+      List.reverse fieldsInReverse
+
+  components <- collectComponents (fmap fieldSchemaInfo fieldsInOrder)
+
+  let
+
+  pure $
+    SchemaInfo
+      { fleeceName = name
+      , schemaIsPrimitive = False
+      , openApiKey = key
+      , openApiSchema =
+          mempty
+            { OpenApi._schemaType = Just OpenApi.OpenApiObject
+            , OpenApi._schemaProperties = mkProperties fieldsInOrder
+            , OpenApi._schemaRequired = mkRequiredProperties fieldsInOrder
+            , OpenApi._schemaTitle = key
+            }
+      , schemaComponents = components
+      }
+
+fleeceNameToOpenApiKey :: FC.Name -> T.Text
+fleeceNameToOpenApiKey =
+  T.pack . FC.nameUnqualified
+
+-- TODO this is a hack pending a better solution in json-fleece.
+rewriteSchemaInfo :: SchemaInfo -> SchemaInfo
+rewriteSchemaInfo schemaInfo =
+  case FC.nameUnqualified $ fleeceName schemaInfo of
+    "Int" -> mkPrimitiveSchema "integer" OpenApi.OpenApiInteger
+    "Int64" -> setSchemaInfoFormat "int64" $ mkPrimitiveSchema "integer" OpenApi.OpenApiInteger
+    "Int32" -> setSchemaInfoFormat "int32" $ mkPrimitiveSchema "integer" OpenApi.OpenApiInteger
+    "UTCTime" -> setSchemaInfoFormat "date-time" $ mkPrimitiveSchema "string" OpenApi.OpenApiString
+    _ -> schemaInfo
+
+componentsPrefix :: T.Text
+componentsPrefix =
+  "#/components/schemas/"

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,6 +1,142 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Main
   ( main
   ) where
 
+import Beeline.Routing ((/-), (/:))
+import Beeline.Routing qualified as R
+import Data.Aeson.Encode.Pretty qualified as AesonPretty
+import Data.ByteString.Char8 as BS8
+import Data.ByteString.Lazy as LBS
+import Data.FileEmbed qualified as FileEmbed
+import Data.OpenApi qualified as OpenApi
+import Data.Void qualified as Void
+import Hedgehog ((===))
+import Hedgehog qualified as HH
+import Shrubbery qualified as S
+import Test.Tasty qualified as Tasty
+import Test.Tasty.Hedgehog qualified as TastyHH
+
+import Orb qualified
+
 main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+main =
+  Tasty.defaultMain $
+    Tasty.testGroup
+      "Orb"
+      [ testGroup
+      ]
+
+testGroup :: Tasty.TestTree
+testGroup =
+  Tasty.testGroup
+    "OpenApi"
+    [ TastyHH.testProperty "can generate a requested open api json" prop_openApi
+    , TastyHH.testProperty "cannot generate an unknown open api" prop_openApiUnknownLabel
+    , TastyHH.testProperty "can generate a requested open api json for a subset of routes" prop_openApiSubset
+    ]
+
+prop_openApi :: HH.Property
+prop_openApi = HH.withTests 1 . HH.property $ do
+  openApi <- HH.evalEither (Orb.mkOpenApi router "basic-open-api")
+  assertEqualOpenApi openApi $(FileEmbed.embedFile "test/examples/basic-open-api.json")
+
+prop_openApiUnknownLabel :: HH.Property
+prop_openApiUnknownLabel = HH.withTests 1 . HH.property $ do
+  case Orb.mkOpenApi router "unknown-open-api" of
+    Right _ -> fail "Should not have returned an OpenApi for an unknown label"
+    Left msg -> msg === "No OpenApi definition found with label unknown-open-api."
+
+prop_openApiSubset :: HH.Property
+prop_openApiSubset = HH.withTests 1 . HH.property $ do
+  openApi <- HH.evalEither (Orb.mkOpenApi router "just-route-1")
+  assertEqualOpenApi openApi $(FileEmbed.embedFile "test/examples/just-route-1.json")
+
+router :: Orb.OpenApiProvider r => r (S.Union [TestRoute1, TestRoute2])
+router =
+  Orb.provideOpenApi "basic-open-api"
+    . R.routeList
+    $ Orb.provideOpenApi "just-route-1" (Orb.get (R.make TestRoute1 /- "test/route1"))
+      /: Orb.get (R.make TestRoute2 /- "test/route2")
+      /: R.emptyRoutes
+
+assertEqualOpenApi :: HH.MonadTest m => OpenApi.OpenApi -> BS8.ByteString -> m ()
+assertEqualOpenApi openApi expectedBytes = do
+  -- Splitting on lines here both produces a more useful diff and allows for small
+  -- meaningless differences such as newline at end of file between the encoded
+  -- bytes and the expected bytes read from the sample file
+  BS8.lines (LBS.toStrict (AesonPretty.encodePretty openApi))
+    === BS8.lines expectedBytes
+
+data TestRoute1 = TestRoute1
+
+instance Orb.HasHandler TestRoute1 where
+  type HandlerRequestBody TestRoute1 = Orb.NoRequestBody
+  type HandlerResponses TestRoute1 = TestResponses
+  type HandlerPermissionAction TestRoute1 = NoPermissions
+  type HandlerMonad TestRoute1 = IO
+  routeHandler = mkTestHandler "testRoute1"
+
+data TestRoute2 = TestRoute2
+
+instance Orb.HasHandler TestRoute2 where
+  type HandlerRequestBody TestRoute2 = Orb.NoRequestBody
+  type HandlerResponses TestRoute2 = TestResponses
+  type HandlerPermissionAction TestRoute2 = NoPermissions
+  type HandlerMonad TestRoute2 = IO
+  routeHandler = mkTestHandler "testRoute2"
+
+type TestResponses =
+  [ Orb.Response200 Orb.SuccessMessage
+  , Orb.Response500 Orb.InternalServerError
+  ]
+
+mkTestHandler ::
+  ( Orb.HandlerPermissionAction route ~ NoPermissions
+  , Orb.HandlerResponses route ~ TestResponses
+  , Orb.HandlerRequestBody route ~ Orb.NoRequestBody
+  , Applicative (Orb.HandlerMonad route)
+  ) =>
+  String ->
+  Orb.Handler route
+mkTestHandler handlerId =
+  Orb.Handler
+    { Orb.handlerId = handlerId
+    , Orb.requestBody = Orb.EmptyRequestBody
+    , Orb.handlerResponseBodies =
+        Orb.responseBodies
+          . Orb.addResponseSchema200 Orb.successMessageSchema
+          . Orb.addResponseSchema500 Orb.internalServerErrorSchema
+          $ Orb.noResponseBodies
+    , Orb.mkPermissionAction =
+        \_route _request -> NoPermissions
+    , Orb.handleRequest =
+        \_route Orb.NoRequestBody () ->
+          Orb.return200 (Orb.SuccessMessage "Hi")
+    }
+
+data NoPermissions
+  = NoPermissions
+
+newtype NoError = NoError Void.Void
+
+instance Orb.PermissionAction NoPermissions where
+  type PermissionActionMonad NoPermissions = IO
+  type PermissionActionError NoPermissions = NoError
+  type PermissionActionResult NoPermissions = ()
+
+  checkPermissionAction _ =
+    pure (Right ())
+
+instance Orb.PermissionError NoError where
+  type PermissionErrorConstraints NoError _tags = ()
+  type PermissionErrorMonad NoError = IO
+
+  returnPermissionError (NoError void) =
+    Void.absurd void

--- a/test/examples/basic-open-api.json
+++ b/test/examples/basic-open-api.json
@@ -1,0 +1,91 @@
+{
+    "components": {
+        "schemas": {
+            "InternalServerError": {
+                "properties": {
+                    "internal_server_error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "internal_server_error"
+                ],
+                "title": "InternalServerError",
+                "type": "object"
+            },
+            "SuccessMessage": {
+                "properties": {
+                    "success": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "success"
+                ],
+                "title": "SuccessMessage",
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/test/route1": {
+            "get": {
+                "operationId": "testRoute1",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessMessage"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/test/route2": {
+            "get": {
+                "operationId": "testRoute2",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessMessage"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/examples/just-route-1.json
+++ b/test/examples/just-route-1.json
@@ -1,0 +1,64 @@
+{
+    "components": {
+        "schemas": {
+            "InternalServerError": {
+                "properties": {
+                    "internal_server_error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "internal_server_error"
+                ],
+                "title": "InternalServerError",
+                "type": "object"
+            },
+            "SuccessMessage": {
+                "properties": {
+                    "success": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "success"
+                ],
+                "title": "SuccessMessage",
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/test/route1": {
+            "get": {
+                "operationId": "testRoute1",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessMessage"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds facilities for generating an open api spec based
on the Handler definitions described by an Orb router.
The `provideOpenApi` function is used anywhere in a router
to label a section of routes being included in an open-api
spec. The spec is given a label at the time `provideOpenApi`
is called. Once the router is build, `mkOpenApi` can be called
on the root router to retrieve the open api description of
any labeled APIs contained within it. The retrieved API
descriptions will have the correct full path as described
by the root router passed to `mkOpenApi`.

This also provides a helper functions that can be used by
applications to provide a main with an subcommands to
run the Orb api (`api`) or generate an Open API spec based
on the application routes (`generate-open-api`). Various
helpers are exposed to allow the user to compose their
own main function however they ultimately need to.
