### PR TITLE
Keep nullable schemas referenced by name

### DIFF
--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -591,6 +591,7 @@ data SchemaInfo = SchemaInfo
   { fleeceName :: FC.Name
   , schemaIsPrimitive :: Bool
   , openApiKey :: Maybe T.Text
+  , openApiNullable :: Bool
   , openApiSchema :: OpenApi.Schema
   , schemaComponents :: Map.Map T.Text SchemaInfo
   }
@@ -630,7 +631,17 @@ mkSchemaRef ::
 mkSchemaRef schema =
   case openApiKey schema of
     Just schemaKey ->
-      OpenApi.Ref . OpenApi.Reference $ schemaKey
+      let
+        ref = OpenApi.Ref . OpenApi.Reference $ schemaKey
+      in
+        if openApiNullable schema
+          then
+            OpenApi.Inline $
+              mempty
+                { OpenApi._schemaOneOf = Just [ref]
+                , OpenApi._schemaNullable = Just True
+                }
+          else ref
     Nothing ->
       OpenApi.Inline . openApiSchema $ schema
 
@@ -643,6 +654,7 @@ mkPrimitiveSchema name openApiType =
     { fleeceName = FC.unqualifiedName name
     , schemaIsPrimitive = True
     , openApiKey = Nothing
+    , openApiNullable = False
     , openApiSchema =
         mempty
           { OpenApi._schemaType = Just openApiType
@@ -703,6 +715,7 @@ instance FC.Fleece FleeceOpenApi where
           { fleeceName = FC.annotateName (fleeceName itemSchemaInfo) "array"
           , schemaIsPrimitive = False
           , openApiKey = Nothing
+          , openApiNullable = False
           , openApiSchema =
               mempty
                 { OpenApi._schemaType = Just OpenApi.OpenApiArray
@@ -714,18 +727,20 @@ instance FC.Fleece FleeceOpenApi where
   nullable (FleeceOpenApi errOrSchemaInfo) =
     FleeceOpenApi $ do
       schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
-      components <- collectComponents [schemaInfo]
 
+      let
+        name = fleeceName schemaInfo
       pure $
         SchemaInfo
-          { fleeceName = FC.annotateName (fleeceName schemaInfo) "nullable"
+          { fleeceName = name
           , schemaIsPrimitive = schemaIsPrimitive schemaInfo
-          , openApiKey = Nothing
+          , openApiKey = Just $ fleeceNameToOpenApiKey name
+          , openApiNullable = True
           , openApiSchema =
               (openApiSchema schemaInfo)
                 { OpenApi._schemaNullable = Just True
                 }
-          , schemaComponents = components
+          , schemaComponents = mempty
           }
 
   required name _accessor (FleeceOpenApi errOrSchemaInfo) =
@@ -777,6 +792,7 @@ instance FC.Fleece FleeceOpenApi where
             schemaInfo
               { fleeceName = name
               , openApiKey = Just . fleeceNameToOpenApiKey $ name
+              , openApiNullable = False
               , schemaComponents = components
               }
         else pure schemaInfo
@@ -794,6 +810,7 @@ instance FC.Fleece FleeceOpenApi where
           { fleeceName = name
           , schemaIsPrimitive = False
           , openApiKey = Just . fleeceNameToOpenApiKey $ name
+          , openApiNullable = False
           , openApiSchema =
               mempty
                 { OpenApi._schemaType = Just OpenApi.OpenApiString
@@ -871,6 +888,7 @@ instance FC.Fleece FleeceOpenApi where
           { fleeceName = name
           , schemaIsPrimitive = False
           , openApiKey = key
+          , openApiNullable = False
           , openApiSchema =
               mempty
                 { OpenApi._schemaType = Nothing
@@ -933,6 +951,7 @@ mkObjectForFields name fieldsInReverse = do
       { fleeceName = name
       , schemaIsPrimitive = False
       , openApiKey = key
+      , openApiNullable = False
       , openApiSchema =
           mempty
             { OpenApi._schemaType = Just OpenApi.OpenApiObject

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -736,10 +736,7 @@ instance FC.Fleece FleeceOpenApi where
           , schemaIsPrimitive = schemaIsPrimitive schemaInfo
           , openApiKey = Just $ fleeceNameToOpenApiKey name
           , openApiNullable = True
-          , openApiSchema =
-              (openApiSchema schemaInfo)
-                { OpenApi._schemaNullable = Just True
-                }
+          , openApiSchema = openApiSchema schemaInfo
           , schemaComponents = mempty
           }
 

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -27,7 +27,7 @@ basicOpenApiRouter =
     . R.routeList
     $ Orb.provideOpenApi "just-route-1" (Orb.get (R.make TestRoute1 /- "test/route1"))
       /: Orb.get (R.make TestRoute2 /- "test/route2")
-      /: Orb.provideOpenApi "nullable-ref" (Orb.get (R.make NullableRef /- "nullable-ref"))
+      /: Orb.get (R.make NullableRef /- "nullable-ref")
       /: R.emptyRoutes
 
 -- Nullable Ref

--- a/test/examples/basic-open-api.json
+++ b/test/examples/basic-open-api.json
@@ -26,7 +26,6 @@
                 "type": "object"
             },
             "WrappedInteger": {
-                "nullable": true,
                 "properties": {
                     "field": {
                         "type": "integer"

--- a/test/examples/basic-open-api.json
+++ b/test/examples/basic-open-api.json
@@ -24,6 +24,19 @@
                 ],
                 "title": "SuccessMessage",
                 "type": "object"
+            },
+            "WrappedInteger": {
+                "nullable": true,
+                "properties": {
+                    "field": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "field"
+                ],
+                "title": "WrappedInteger",
+                "type": "object"
             }
         }
     },
@@ -33,6 +46,38 @@
     },
     "openapi": "3.0.0",
     "paths": {
+        "/nullable-ref": {
+            "get": {
+                "operationId": "NullableRefHandler",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "nullable": true,
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/WrappedInteger"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/test/route1": {
             "get": {
                 "operationId": "testRoute1",


### PR DESCRIPTION
Before this PR, object properties such as
`FC.optionalNullable FC.EmitNull selector giantObjectSchema` would cause `giantObjectSchema` to be inlined at the use site, i.e. in the object where optionalNullable was invoked.

This duplication of the encoding of `GiantObject` is unnecessary, since we *can* mark any named schema as
nullable, by having it be the sole inhabitant of e.g. a `oneOf`.

In fact, this structure is proposed by the [official Swagger
editor](https://editor.swagger.io): For example if you try put `nullable` next
to `$ref`, it will note that it is invalid, and suggest using `oneOf`.

So in this PR, we instead generate this slightly awkward encoding, which I
consider an improvement since it avoids inlining at every use site.
