### PR TITLE
Fixes bug in OpenAPI Fleece instance `nullable` method

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -92,6 +92,7 @@ library
     , mtl
     , openapi3
     , optparse-applicative
+    , pretty-show
     , safe-exceptions
     , semialign
     , shrubbery
@@ -141,6 +142,7 @@ test-suite orb-test
     , openapi3
     , optparse-applicative
     , orb
+    , pretty-show
     , safe-exceptions
     , semialign
     , shrubbery

--- a/orb.cabal
+++ b/orb.cabal
@@ -92,7 +92,6 @@ library
     , mtl
     , openapi3
     , optparse-applicative
-    , pretty-show
     , safe-exceptions
     , semialign
     , shrubbery
@@ -142,7 +141,6 @@ test-suite orb-test
     , openapi3
     , optparse-applicative
     , orb
-    , pretty-show
     , safe-exceptions
     , semialign
     , shrubbery

--- a/orb.cabal
+++ b/orb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.1.5
+version:        0.1.6
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues

--- a/package.yaml
+++ b/package.yaml
@@ -73,6 +73,7 @@ dependencies:
   - wai
   - wai-extra
   - warp
+  - pretty-show
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                orb
-version:             0.1.5
+version:             0.1.6
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"

--- a/package.yaml
+++ b/package.yaml
@@ -73,7 +73,6 @@ dependencies:
   - wai
   - wai-extra
   - warp
-  - pretty-show
 
 library:
   source-dirs: src

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -31,6 +31,7 @@ import Fleece.Core qualified as FC
 import GHC.TypeLits (symbolVal)
 import Network.HTTP.Media.MediaType qualified as MediaType
 import Network.HTTP.Types qualified as HTTPTypes
+import Text.Show.Pretty (ppShow)
 
 import Orb.Handler qualified as Handler
 import Orb.Response qualified as Response
@@ -171,6 +172,10 @@ combineSchemaComponents left right =
                   <> FC.nameToString (fleeceName this)
                   <> " and "
                   <> FC.nameToString (fleeceName that)
+                  <> ": "
+                  <> ppShow this
+                  <> "\n"
+                  <> ppShow that
 
     addKeyToError :: T.Text -> Either String a -> Either String a
     addKeyToError key errOrSchemaInfo =
@@ -595,7 +600,7 @@ data SchemaInfo = SchemaInfo
   , openApiSchema :: OpenApi.Schema
   , schemaComponents :: Map.Map T.Text SchemaInfo
   }
-  deriving (Eq)
+  deriving (Eq, Show)
 
 setSchemaInfoFormat :: T.Text -> SchemaInfo -> SchemaInfo
 setSchemaInfoFormat fmt info =
@@ -737,7 +742,7 @@ instance FC.Fleece FleeceOpenApi where
           , openApiKey = Just $ fleeceNameToOpenApiKey name
           , openApiNullable = True
           , openApiSchema = openApiSchema schemaInfo
-          , schemaComponents = mempty
+          , schemaComponents = schemaComponents schemaInfo
           }
 
   required name _accessor (FleeceOpenApi errOrSchemaInfo) =

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -27,7 +27,6 @@ import Data.Maybe qualified as Maybe
 import Data.OpenApi qualified as OpenApi
 import Data.Text qualified as T
 import Data.These qualified as These
-import Debug.Trace qualified as Debug
 import Fleece.Core qualified as FC
 import GHC.TypeLits (symbolVal)
 import Network.HTTP.Media.MediaType qualified as MediaType
@@ -646,7 +645,7 @@ mkSchemaRef schema =
           then
             OpenApi.Inline $
               mempty
-                { OpenApi._schemaOneOf = Debug.traceShowId (Just [ref])
+                { OpenApi._schemaOneOf = Just [ref]
                 , OpenApi._schemaNullable = Just True
                 }
           else ref
@@ -740,7 +739,7 @@ instance FC.Fleece FleeceOpenApi where
         SchemaInfo
           { fleeceName = fleeceName schemaInfo
           , schemaIsPrimitive = schemaIsPrimitive schemaInfo
-          , openApiKey = Debug.traceShowId $ openApiKey schemaInfo
+          , openApiKey = openApiKey schemaInfo
           , openApiNullable = True
           , openApiSchema =
               (openApiSchema schemaInfo)

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -597,12 +597,23 @@ data SchemaInfo = SchemaInfo
   }
 
 isSameSchemaInfo :: SchemaInfo -> SchemaInfo -> Bool
-isSameSchemaInfo (SchemaInfo a1 b1 c1 _ d1 e1) (SchemaInfo a2 b2 c2 _ d2 e2) =
-  a1 == a2
-    && b1 == b2
-    && c1 == c2
-    && d1 == d2
-    && and (Align.alignWith (These.these (const False) (const False) isSameSchemaInfo) e1 e2)
+isSameSchemaInfo
+  (SchemaInfo fleeceName1 schemaIsPrimitive1 openApiKey1 _ openApiNullable1 schemaComponents1)
+  (SchemaInfo fleeceName2 schemaIsPrimitive2 openApiKey2 _ openApiNullable2 schemaComponents2) =
+    fleeceName1 == fleeceName2
+      && schemaIsPrimitive1 == schemaIsPrimitive2
+      && openApiKey1 == openApiKey2
+      && openApiNullable1 == openApiNullable2
+      && and
+        ( Align.alignWith
+            ( These.these
+                (const False)
+                (const False)
+                isSameSchemaInfo
+            )
+            schemaComponents1
+            schemaComponents2
+        )
 
 setSchemaInfoFormat :: T.Text -> SchemaInfo -> SchemaInfo
 setSchemaInfoFormat fmt info =

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -76,7 +76,15 @@ instance Orb.HasHandler NullableRef where
           \_route _request -> NoPermissions
       , Orb.handleRequest =
           \_route Orb.NoRequestBody () ->
-            Orb.return200 (Right $ NullableRefResponse 42)
+            Orb.return200
+              ( Right
+                  NullableRefResponse
+                    { boolField = False
+                    , nullableBoolField = Right False
+                    , validatedNullableBoolField = Right False
+                    , nullableValidatedBoolField = Right False
+                    }
+              )
       }
 
 type NullableRefResponses =
@@ -84,13 +92,21 @@ type NullableRefResponses =
   , Orb.Response500 Orb.InternalServerError
   ]
 
-newtype NullableRefResponse = NullableRefResponse {unNullableRefResponse :: Int}
+data NullableRefResponse = NullableRefResponse
+  { boolField :: Bool
+  , nullableBoolField :: Either FC.Null Bool
+  , validatedNullableBoolField :: Either FC.Null Bool
+  , nullableValidatedBoolField :: Either FC.Null Bool
+  }
 
 nullableRefResponseSchema :: FC.Fleece schema => schema NullableRefResponse
 nullableRefResponseSchema =
-  FC.objectNamed "WrappedInteger" $
+  FC.object $
     FC.constructor NullableRefResponse
-      #+ FC.required "field" unNullableRefResponse FC.int
+      #+ FC.required "boolField" boolField FC.boolean
+      #+ FC.required "nullableBoolField" nullableBoolField (FC.nullable FC.boolean)
+      #+ FC.required "validatedNullableBoolField" validatedNullableBoolField (FC.transformNamed "MyNullableBool" id id (FC.nullable FC.boolean))
+      #+ FC.required "nullableValidatedBoolField" nullableValidatedBoolField (FC.nullable (FC.transformNamed "MyBool" id id FC.boolean))
 
 -- Nullable Ref Collect Components
 
@@ -115,7 +131,15 @@ instance Orb.HasHandler NullableRefCollectComponents where
           \_route _request -> NoPermissions
       , Orb.handleRequest =
           \_route Orb.NoRequestBody () ->
-            Orb.return200 (Right NullableRefCollectComponentsResponse {outerField = InnerObject {innerField = False}})
+            Orb.return200
+              ( Right
+                  NullableRefCollectComponentsResponse
+                    { outerField =
+                        InnerObject
+                          { innerField = False
+                          }
+                    }
+              )
       }
 
 type NullableRefCollectComponentsResponses =

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -83,6 +83,8 @@ instance Orb.HasHandler NullableRef where
                     , nullableBoolField = Right False
                     , validatedNullableBoolField = Right False
                     , nullableValidatedBoolField = Right False
+                    , nullableArrayField = Right []
+                    , arrayOfNullableField = []
                     }
               )
       }
@@ -97,6 +99,8 @@ data NullableRefResponse = NullableRefResponse
   , nullableBoolField :: Either FC.Null Bool
   , validatedNullableBoolField :: Either FC.Null Bool
   , nullableValidatedBoolField :: Either FC.Null Bool
+  , nullableArrayField :: Either FC.Null [Bool]
+  , arrayOfNullableField :: [Either FC.Null Bool]
   }
 
 nullableRefResponseSchema :: FC.Fleece schema => schema NullableRefResponse
@@ -107,6 +111,8 @@ nullableRefResponseSchema =
       #+ FC.required "nullableBoolField" nullableBoolField (FC.nullable FC.boolean)
       #+ FC.required "validatedNullableBoolField" validatedNullableBoolField (FC.transformNamed "MyNullableBool" id id (FC.nullable FC.boolean))
       #+ FC.required "nullableValidatedBoolField" nullableValidatedBoolField (FC.nullable (FC.transformNamed "MyBool" id id FC.boolean))
+      #+ FC.required "nullableArrayField" nullableArrayField (FC.nullable (FC.list FC.boolean))
+      #+ FC.required "arrayOfNullableField" arrayOfNullableField (FC.list (FC.nullable FC.boolean))
 
 -- Nullable Ref Collect Components
 

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -92,7 +92,7 @@ nullableRefResponseSchema =
     FC.constructor NullableRefResponse
       #+ FC.required "field" unNullableRefResponse FC.int
 
--- Nullable Ref
+-- Nullable Ref Collect Components
 
 data NullableRefCollectComponents = NullableRefCollectComponents
 
@@ -108,6 +108,7 @@ instance Orb.HasHandler NullableRefCollectComponents where
       , Orb.handlerResponseBodies =
           Orb.responseBodies
             . Orb.addResponseSchema200 (FC.nullable nullableRefCollectComponentsResponseSchema)
+            . Orb.addResponseSchema400 nullableRefCollectComponentsResponseSchema
             . Orb.addResponseSchema500 Orb.internalServerErrorSchema
             $ Orb.noResponseBodies
       , Orb.mkPermissionAction =
@@ -119,6 +120,7 @@ instance Orb.HasHandler NullableRefCollectComponents where
 
 type NullableRefCollectComponentsResponses =
   [ Orb.Response200 (Either FC.Null NullableRefCollectComponentsResponse)
+  , Orb.Response400 NullableRefCollectComponentsResponse
   , Orb.Response500 Orb.InternalServerError
   ]
 

--- a/test/OpenApi.hs
+++ b/test/OpenApi.hs
@@ -25,6 +25,7 @@ testGroup =
     , test_openApiSubset
     , test_nullableRefOpenApi
     , test_unionOpenApi
+    , test_nullableRefCollectComponentsOpenApi
     ]
 
 test_openApi :: Tasty.TestTree
@@ -60,6 +61,13 @@ test_unionOpenApi =
     "Generates the correct OpenAPI JSON for a union schema"
     "test/examples/union.json"
     $ Orb.mkOpenApi Fixtures.unionOpenApiRouter "union"
+
+test_nullableRefCollectComponentsOpenApi :: Tasty.TestTree
+test_nullableRefCollectComponentsOpenApi =
+  mkGoldenTest
+    "Generates the correct OpenAPI JSON for a nullable schema with an inner object schema"
+    "test/examples/nullable-ref-collect-components.json"
+    $ Orb.mkOpenApi Fixtures.nullableRefCollectComponentsOpenApiRouter "nullable-ref-collect-components"
 
 mkGoldenTest ::
   Tasty.TestName ->

--- a/test/examples/nullable-ref-collect-components.json
+++ b/test/examples/nullable-ref-collect-components.json
@@ -1,0 +1,81 @@
+{
+    "components": {
+        "schemas": {
+            "InnerObject": {
+                "properties": {
+                    "innerField": {
+                        "type": "boolean"
+                    }
+                },
+                "required": [
+                    "innerField"
+                ],
+                "title": "InnerObject",
+                "type": "object"
+            },
+            "InternalServerError": {
+                "properties": {
+                    "internal_server_error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "internal_server_error"
+                ],
+                "title": "InternalServerError",
+                "type": "object"
+            },
+            "NullableRefCollectComponentsResponse": {
+                "properties": {
+                    "outerField": {
+                        "$ref": "#/components/schemas/InnerObject"
+                    }
+                },
+                "required": [
+                    "outerField"
+                ],
+                "title": "NullableRefCollectComponentsResponse",
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/nullable-ref-collect-components": {
+            "get": {
+                "operationId": "NullableRefCollectComponentsHandler",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "nullable": true,
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/components/schemas/NullableRefCollectComponentsResponse"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/examples/nullable-ref-collect-components.json
+++ b/test/examples/nullable-ref-collect-components.json
@@ -64,6 +64,16 @@
                         },
                         "description": ""
                     },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NullableRefCollectComponentsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
                     "500": {
                         "content": {
                             "application/json": {

--- a/test/examples/nullable-ref.json
+++ b/test/examples/nullable-ref.json
@@ -13,16 +13,41 @@
                 "title": "InternalServerError",
                 "type": "object"
             },
-            "WrappedInteger": {
+            "MyBool": {
+                "type": "boolean"
+            },
+            "MyNullableBool": {
+                "nullable": true,
+                "type": "boolean"
+            },
+            "NullableRefResponse": {
                 "properties": {
-                    "field": {
-                        "type": "integer"
+                    "boolField": {
+                        "type": "boolean"
+                    },
+                    "nullableBoolField": {
+                        "nullable": true,
+                        "type": "boolean"
+                    },
+                    "nullableValidatedBoolField": {
+                        "nullable": true,
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/MyBool"
+                            }
+                        ]
+                    },
+                    "validatedNullableBoolField": {
+                        "$ref": "#/components/schemas/MyNullableBool"
                     }
                 },
                 "required": [
-                    "field"
+                    "boolField",
+                    "nullableBoolField",
+                    "validatedNullableBoolField",
+                    "nullableValidatedBoolField"
                 ],
-                "title": "WrappedInteger",
+                "title": "NullableRefResponse",
                 "type": "object"
             }
         }
@@ -44,7 +69,7 @@
                                     "nullable": true,
                                     "oneOf": [
                                         {
-                                            "$ref": "#/components/schemas/WrappedInteger"
+                                            "$ref": "#/components/schemas/NullableRefResponse"
                                         }
                                     ]
                                 }

--- a/test/examples/nullable-ref.json
+++ b/test/examples/nullable-ref.json
@@ -22,8 +22,22 @@
             },
             "NullableRefResponse": {
                 "properties": {
+                    "arrayOfNullableField": {
+                        "items": {
+                            "nullable": true,
+                            "type": "boolean"
+                        },
+                        "type": "array"
+                    },
                     "boolField": {
                         "type": "boolean"
+                    },
+                    "nullableArrayField": {
+                        "items": {
+                            "type": "boolean"
+                        },
+                        "nullable": true,
+                        "type": "array"
                     },
                     "nullableBoolField": {
                         "nullable": true,
@@ -45,7 +59,9 @@
                     "boolField",
                     "nullableBoolField",
                     "validatedNullableBoolField",
-                    "nullableValidatedBoolField"
+                    "nullableValidatedBoolField",
+                    "nullableArrayField",
+                    "arrayOfNullableField"
                 ],
                 "title": "NullableRefResponse",
                 "type": "object"


### PR DESCRIPTION
A previous commit accidentally removed the call to `collectComponents` in the `nullable` method of the `Fleece` instance for `FleeceOpenApi`, when it should have replaced it with the descendant components of the schema being made nullable. We added a test case to ensure the correct OpenAPI schema is generated for fleece schemas with non-primitive child schemas.

Note that this depends on #22 for the test separation.