### PR TITLE
Add streaming responses

### DIFF
--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -179,12 +179,14 @@ emptyRequestBodyHandler bodies action = do
       maybeToList $
         ("Content-Type",)
           <$> Response.responseDataContentType responseData
+    status = Response.responseDataStatus responseData
+    headers = contentTypeHeader <> Response.responseDataExtraHeaders responseData
 
   Response.respondWith $
-    Wai.responseLBS
-      (Response.responseDataStatus responseData)
-      (contentTypeHeader <> Response.responseDataExtraHeaders responseData)
-      (Response.responseDataBytes responseData)
+    case Response.responseDataContent responseData of
+      Response.ResponseContentFile path mbPart -> Wai.responseFile status headers path mbPart
+      Response.ResponseContentBuilder builder -> Wai.responseBuilder status headers builder
+      Response.ResponseContentStream streamingBody -> Wai.responseStream status headers streamingBody
 
 requestFormDataHandler ::
   ( Response.Has400Response tags

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -479,7 +479,7 @@ mkResponses handler =
     addResponse (responses, components) (status, responseSchema) = do
       mbSchemaInfo <-
         case responseSchema of
-          Response.ResponseContent _contentType _encoder -> pure Nothing
+          Response.ResponseContent _contentType -> pure Nothing
           Response.ResponseSchema (FleeceOpenApi info) -> fmap Just info
           Response.ResponseDocument -> pure Nothing
           Response.EmptyResponseBody -> pure Nothing


### PR DESCRIPTION
This adds a ResponseContent type which mirrors the `Response` type in WAI. The
WAI type also has Raw, which is used for stuff like Websocket upgrades. That
didn't seem to be in scope for this story, so I left it out. I kept `File`
because it seems simple and I could imagine us using it for serving large files
using the sendfile syscall without having to bother with Conduit. So it seems
like it also serves the streaming use case.
