### PR TITLE
Allow dynamically deciding content-type, v0.4

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.38.1.
 --
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.3.0.0
+version:        0.4.0.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                orb
-version:             0.3.0.0
+version:             0.4.0.0
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"

--- a/src/Orb/Handler/Handler.hs
+++ b/src/Orb/Handler/Handler.hs
@@ -107,15 +107,15 @@ data NoRequestBody
   = NoRequestBody
 
 data RequestBody body tags where
-  RequestSchema ::
+  SchemaRequestBody ::
     Response.Has422Response tags =>
     (forall schema. FC.Fleece schema => schema body) ->
     RequestBody body tags
-  RequestRawBody ::
+  RawRequestBody ::
     Response.HasResponseCodeWithType tags "422" err =>
     (LBS.ByteString -> Either err body) ->
     RequestBody body tags
-  RequestFormData ::
+  FormDataRequestBody ::
     (Response.Has400Response tags, Response.HasResponseCodeWithType tags "422" err) =>
     (Form -> Either err body) ->
     RequestBody body tags
@@ -243,9 +243,9 @@ readBody ::
   m (Either (S.TaggedUnion tags) (HandlerRequestBody route))
 readBody handler =
   case requestBody handler of
-    RequestSchema schema -> parseBodyRequestSchema schema
-    RequestRawBody bodyDecoder -> parseBodyRaw bodyDecoder
-    RequestFormData formDecoder -> parseBodyFormData formDecoder
+    SchemaRequestBody schema -> parseBodyRequestSchema schema
+    RawRequestBody bodyDecoder -> parseBodyRaw bodyDecoder
+    FormDataRequestBody formDecoder -> parseBodyFormData formDecoder
     EmptyRequestBody -> pure . Right $ NoRequestBody
 
 runPermissionAction ::

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -439,7 +439,7 @@ mkRequestBody ::
   Either String (Maybe (OpenApi.Referenced OpenApi.RequestBody, Map.Map T.Text SchemaInfo))
 mkRequestBody handler =
   case Handler.requestBody handler of
-    Handler.RequestSchema (FleeceOpenApi errOrSchemaInfo) -> do
+    Handler.SchemaRequestBody (FleeceOpenApi errOrSchemaInfo) -> do
       schemaInfo <- fmap rewriteSchemaInfo errOrSchemaInfo
 
       let
@@ -464,9 +464,9 @@ mkRequestBody handler =
 
       components <- collectComponents [schemaInfo]
       pure $ Just (requestBody, components)
-    Handler.RequestRawBody _decoder ->
+    Handler.RawRequestBody _decoder ->
       Right Nothing
-    Handler.RequestFormData _formDecoder ->
+    Handler.FormDataRequestBody _formDecoder ->
       Right Nothing
     Handler.EmptyRequestBody ->
       Right Nothing
@@ -566,9 +566,8 @@ mkResponses handler =
     addResponse (responses, components) (status, responseSchema) = do
       mbSchemaInfo <-
         case responseSchema of
-          Response.ResponseContent _contentType -> pure Nothing
-          Response.ResponseSchema (FleeceOpenApi info) -> fmap Just info
-          Response.ResponseDocument -> pure Nothing
+          Response.NoSchemaResponseBody _mbContentType -> pure Nothing
+          Response.SchemaResponseBody (FleeceOpenApi info) -> fmap Just info
           Response.EmptyResponseBody -> pure Nothing
       let
         mkResponseContent schemaRef =

--- a/src/Orb/Response/Response.hs
+++ b/src/Orb/Response/Response.hs
@@ -42,12 +42,10 @@ responseBodyList =
   Map.toList . responseStatusMap
 
 data ResponseBody where
-  ResponseContent ::
-    ContentType -> ResponseBody
-  ResponseSchema ::
+  NoSchemaResponseBody ::
+    Maybe ContentType -> ResponseBody
+  SchemaResponseBody ::
     (forall schema. FC.Fleece schema => schema body) -> ResponseBody
-  ResponseDocument ::
-    ResponseBody
   EmptyResponseBody ::
     ResponseBody
 

--- a/src/Orb/Response/StatusCodes.hs
+++ b/src/Orb/Response/StatusCodes.hs
@@ -358,7 +358,7 @@ addResponseBodyWithResponseContent mbContentType mkResponseContent builder =
       , responseStatusMapBuilder =
           Map.insert
             status
-            (maybe ResponseDocument ResponseContent mbContentType)
+            (NoSchemaResponseBody mbContentType)
             (responseStatusMapBuilder builder)
       }
 
@@ -400,7 +400,7 @@ addResponseSchema schema builder =
       , responseStatusMapBuilder =
           Map.insert
             status
-            (ResponseSchema schema)
+            (SchemaResponseBody schema)
             (responseStatusMapBuilder builder)
       }
 
@@ -444,7 +444,7 @@ addResponseDocument builder =
       { encodeResponseBranchesBuilder =
           S.taggedBranch @tag encodeDocument (encodeResponseBranchesBuilder builder)
       , responseStatusMapBuilder =
-          Map.insert status ResponseDocument (responseStatusMapBuilder builder)
+          Map.insert status (NoSchemaResponseBody Nothing) (responseStatusMapBuilder builder)
       }
 
 {- | Associates a /no-content/ type response with a given status code in the

--- a/test/Fixtures/SimplePost.hs
+++ b/test/Fixtures/SimplePost.hs
@@ -54,7 +54,7 @@ handler :: Orb.Handler SimplePost
 handler =
   Orb.Handler
     { Orb.handlerId = "simplePost"
-    , Orb.requestBody = Orb.RequestSchema simplePostBodySchema
+    , Orb.requestBody = Orb.SchemaRequestBody simplePostBodySchema
     , Orb.requestQuery = Orb.EmptyRequestQuery
     , Orb.requestHeaders = Orb.EmptyRequestHeaders
     , Orb.handlerResponseBodies =


### PR DESCRIPTION
With this change, it becomes possible to select the Content-Type
dynamically, but without using a Document.

In this context, dynamic is when the actual response is getting built,
as opposed to static, which would be up front, and renderable to OpenAPI.

Documents force the use of Content-Disposition, which might not always
be desired.

This is a breaking change, but addResponseBodyWithResponseContent was
introduced very recently, so it shouldn't break many.
