### PR TITLE
Allows handlers and permission actions to use different monads

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.4.0.0
+version:        0.5.0.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                orb
-version:             0.4.0.0
+version:             0.5.0.0
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"

--- a/src/Orb/Handler/Dispatchable.hs
+++ b/src/Orb/Handler/Dispatchable.hs
@@ -19,6 +19,7 @@ import Network.Wai qualified as Wai
 import Shrubbery qualified as S
 
 import Orb.Handler.Handler qualified as Handler
+import Orb.Handler.PermissionAction qualified as PA
 import Orb.HasLogger qualified as HasLogger
 import Orb.HasRequest qualified as HasRequest
 import Orb.HasRespond qualified as HasRespond
@@ -33,7 +34,7 @@ instance
   , HasRespond.HasRespond m
   , MIO.MonadIO m
   , Handler.HasHandler route
-  , Handler.HandlerMonad route ~ m
+  , PA.PermissionActionMonad (Handler.HandlerPermissionAction route) ~ m
   , Safe.MonadCatch m
   ) =>
   Dispatchable m route


### PR DESCRIPTION
This adds a new associated type and method to `PermissionAction` to
allow applications to perform permission checks in a different monad
than the handler monad. In particular, the handler monad may include
evidence of the permission execution (e.g. a user record) in its
context that cannot be present before the permission action is
executed. In that case, a `PermissionAction` can implement
`runPermissionActionHandler` to perform execution of the handler monad
from its own monad.
