### PR TITLE
Adds schema description to OpenApi

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -94,6 +94,7 @@ library
     , json-fleece-aeson
     , json-fleece-core
     , mtl
+    , non-empty-text
     , openapi3
     , optparse-applicative
     , safe-exceptions
@@ -125,6 +126,7 @@ test-suite orb-test
       Fixtures.NullableRef
       Fixtures.NullableRefCollectComponents
       Fixtures.OpenApiSubset
+      Fixtures.SchemaDescriptions
       Fixtures.SimpleGet
       Fixtures.SimplePost
       Fixtures.TaggedUnion
@@ -160,6 +162,7 @@ test-suite orb-test
     , json-fleece-aeson
     , json-fleece-core
     , mtl
+    , non-empty-text
     , openapi3
     , optparse-applicative
     , orb

--- a/package.yaml
+++ b/package.yaml
@@ -66,6 +66,7 @@ dependencies:
   - json-fleece-aeson
   - json-fleece-core
   - mtl
+  - non-empty-text
   - openapi3
   - optparse-applicative
   - safe-exceptions

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -35,6 +35,7 @@ import Data.Hashable (Hashable)
 import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Maybe qualified as Maybe
+import Data.NonEmptyText qualified as NET
 import Data.OpenApi qualified as OpenApi
 import Data.Semialign.Indexed qualified as IAlign
 import Data.Set qualified as Set
@@ -1044,6 +1045,20 @@ instance FC.Fleece FleeceOpenApi where
 
   data TaggedUnionMembers FleeceOpenApi _allTags _handledTags
     = TaggedUnionMembers (Path -> FieldInfo -> String -> Either OpenApiError [(T.Text, SchemaInfo)])
+
+  interpretDescribe net schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        describe schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaDescription = Just $ NET.toText net
+                  }
+            }
+      in
+        fmap describe . mkErrOrSchemaInfo
 
   interpretFormat formatString schema =
     FleeceOpenApi $

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 555a26d2209643a3cc78c442e95264cc84d53d34
+    commit: 161aeaedc699c4bb8e85bfa605d9cf606fb97713
     subdirs:
       - json-fleece-aeson
       - json-fleece-core

--- a/stack-ghc-9.10.yaml.lock
+++ b/stack-ghc-9.10.yaml.lock
@@ -57,29 +57,29 @@ packages:
 - completed:
     name: json-fleece-aeson
     pantry-tree:
-      sha256: 2f639d0b7564d8b18d4e8a6a0f0ebf3147f7f19c7e59b52f975b6ada66e1e5e2
+      sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 24b670aff654405c9d9d03029f6d65ee12b6949ced4130bfb27fe9ac806b2143
-    size: 3075834
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 950abc7e1ce07990f836de5f9bfce6970c7d6ba0f38242fa413c036db3aad6e4
+      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
       size: 491
-    sha256: 24b670aff654405c9d9d03029f6d65ee12b6949ced4130bfb27fe9ac806b2143
-    size: 3075834
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
-    version: 0.10.0.0
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    version: 0.11.0.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 snapshots:
 - completed:
     sha256: 0d0bb681dd5be9b930c8fc070d717aae757b9aed176ae6047d87624b46406816

--- a/stack-ghc-9.6.yaml
+++ b/stack-ghc-9.6.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 555a26d2209643a3cc78c442e95264cc84d53d34
+    commit: 161aeaedc699c4bb8e85bfa605d9cf606fb97713
     subdirs:
       - json-fleece-aeson
       - json-fleece-core

--- a/stack-ghc-9.6.yaml.lock
+++ b/stack-ghc-9.6.yaml.lock
@@ -57,29 +57,29 @@ packages:
 - completed:
     name: json-fleece-aeson
     pantry-tree:
-      sha256: 2f639d0b7564d8b18d4e8a6a0f0ebf3147f7f19c7e59b52f975b6ada66e1e5e2
+      sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 24b670aff654405c9d9d03029f6d65ee12b6949ced4130bfb27fe9ac806b2143
-    size: 3075834
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 950abc7e1ce07990f836de5f9bfce6970c7d6ba0f38242fa413c036db3aad6e4
+      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
       size: 491
-    sha256: 24b670aff654405c9d9d03029f6d65ee12b6949ced4130bfb27fe9ac806b2143
-    size: 3075834
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
-    version: 0.10.0.0
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    version: 0.11.0.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 snapshots:
 - completed:
     sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9

--- a/stack-ghc-9.8.yaml
+++ b/stack-ghc-9.8.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 555a26d2209643a3cc78c442e95264cc84d53d34
+    commit: 161aeaedc699c4bb8e85bfa605d9cf606fb97713
     subdirs:
       - json-fleece-aeson
       - json-fleece-core

--- a/stack-ghc-9.8.yaml.lock
+++ b/stack-ghc-9.8.yaml.lock
@@ -57,29 +57,29 @@ packages:
 - completed:
     name: json-fleece-aeson
     pantry-tree:
-      sha256: 2f639d0b7564d8b18d4e8a6a0f0ebf3147f7f19c7e59b52f975b6ada66e1e5e2
+      sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 24b670aff654405c9d9d03029f6d65ee12b6949ced4130bfb27fe9ac806b2143
-    size: 3075834
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 950abc7e1ce07990f836de5f9bfce6970c7d6ba0f38242fa413c036db3aad6e4
+      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
       size: 491
-    sha256: 24b670aff654405c9d9d03029f6d65ee12b6949ced4130bfb27fe9ac806b2143
-    size: 3075834
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
-    version: 0.10.0.0
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    version: 0.11.0.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/555a26d2209643a3cc78c442e95264cc84d53d34.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 snapshots:
 - completed:
     sha256: 7e724f347d5969cb5e8dde9f9aae30996e3231c29d1dafd45f21f1700d4c4fcb

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -57,29 +57,29 @@ packages:
 - completed:
     name: json-fleece-aeson
     pantry-tree:
-      sha256: 2f639d0b7564d8b18d4e8a6a0f0ebf3147f7f19c7e59b52f975b6ada66e1e5e2
+      sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: c76819e7f52d8a426637868ce29b1d0e6c13040179c70f0ee7a99c4cd611c75e
-    size: 3075170
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/5ac847504c6c7ece612187ccb7c2bc524c1dd295.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/5ac847504c6c7ece612187ccb7c2bc524c1dd295.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 950abc7e1ce07990f836de5f9bfce6970c7d6ba0f38242fa413c036db3aad6e4
+      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
       size: 491
-    sha256: c76819e7f52d8a426637868ce29b1d0e6c13040179c70f0ee7a99c4cd611c75e
-    size: 3075170
+    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
+    size: 3075860
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/5ac847504c6c7ece612187ccb7c2bc524c1dd295.tar.gz
-    version: 0.10.0.0
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    version: 0.11.0.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/5ac847504c6c7ece612187ccb7c2bc524c1dd295.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
 snapshots:
 - completed:
     sha256: 0d0bb681dd5be9b930c8fc070d717aae757b9aed176ae6047d87624b46406816

--- a/test/Fixtures/SchemaDescriptions.hs
+++ b/test/Fixtures/SchemaDescriptions.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Fixtures.SchemaDescriptions
+  ( schemaDescriptionsOpenApiRouter
+  ) where
+
+import Beeline.Routing ((/-), (/:))
+import Beeline.Routing qualified as R
+import Data.Text qualified as T
+import Fleece.Core ((#+))
+import Fleece.Core qualified as FC
+import Shrubbery qualified
+
+import Fixtures.NoPermissions (NoPermissions (NoPermissions))
+import Orb qualified
+import TestDispatchM qualified as TDM
+
+schemaDescriptionsOpenApiRouter ::
+  Orb.OpenApiProvider r =>
+  r (Shrubbery.Union '[SchemaDescriptions])
+schemaDescriptionsOpenApiRouter =
+  Orb.provideOpenApi "schema-descriptions" $
+    R.routeList $
+      (Orb.get (R.make SchemaDescriptions /- T.pack "schema-descriptions"))
+        /: R.emptyRoutes
+
+newtype DescribedObject
+  = DescribedObject
+  { describedObjectContent :: T.Text
+  }
+
+describedObjectSchema :: FC.Fleece t => FC.Schema t DescribedObject
+describedObjectSchema =
+  let
+    objectDescription = T.pack "This is the description for DescribedObject."
+    fieldDescription = T.pack "This is the description for the content field."
+  in
+    FC.describe objectDescription $
+      FC.object $
+        FC.constructor DescribedObject
+          #+ FC.required "content" describedObjectContent (FC.describe fieldDescription FC.text)
+
+data SchemaDescriptions = SchemaDescriptions
+
+instance Orb.HasHandler SchemaDescriptions where
+  type HandlerResponses SchemaDescriptions = SchemaDescriptionsResponses
+  type HandlerPermissionAction SchemaDescriptions = NoPermissions
+  type HandlerMonad SchemaDescriptions = TDM.TestDispatchM
+  routeHandler =
+    Orb.Handler
+      { Orb.handlerId = "SchemaDescriptionsHandler"
+      , Orb.requestBody = Orb.EmptyRequestBody
+      , Orb.requestQuery = Orb.EmptyRequestQuery
+      , Orb.requestHeaders = Orb.EmptyRequestHeaders
+      , Orb.handlerResponseBodies =
+          Orb.responseBodies
+            . Orb.addResponseSchema200 describedObjectSchema
+            . Orb.addResponseSchema500 Orb.internalServerErrorSchema
+            $ Orb.noResponseBodies
+      , Orb.mkPermissionAction =
+          \_request -> NoPermissions
+      , Orb.handleRequest =
+          \_request () ->
+            Orb.return200 . DescribedObject $ T.pack "Described content."
+      }
+
+type SchemaDescriptionsResponses =
+  [ Orb.Response200 DescribedObject
+  , Orb.Response500 Orb.InternalServerError
+  ]

--- a/test/examples/schema-descriptions.json
+++ b/test/examples/schema-descriptions.json
@@ -1,0 +1,66 @@
+{
+    "components": {
+        "schemas": {
+            "DescribedObject": {
+                "description": "This is the description for DescribedObject.",
+                "properties": {
+                    "content": {
+                        "description": "This is the description for the content field.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "content"
+                ],
+                "title": "DescribedObject",
+                "type": "object"
+            },
+            "InternalServerError": {
+                "properties": {
+                    "internal_server_error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "internal_server_error"
+                ],
+                "title": "InternalServerError",
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/schema-descriptions": {
+            "get": {
+                "operationId": "SchemaDescriptionsHandler",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DescribedObject"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This uses the new Fleece mechanics for adding descriptions to set a schema description in the generated OpenAPI spec.