### PR TITLE
Makes open api path params have the correct type

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -121,6 +121,7 @@ test-suite orb-test
       Fixtures
       Fixtures.GetWithCookies
       Fixtures.GetWithHeaders
+      Fixtures.GetWithPathParams
       Fixtures.GetWithQuery
       Fixtures.NoPermissions
       Fixtures.NullableRef

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -755,12 +755,7 @@ mkOpenApiPathParam param =
     { OpenApi._paramName = R.parameterName param
     , OpenApi._paramIn = OpenApi.ParamPath
     , OpenApi._paramRequired = Just True
-    , OpenApi._paramSchema =
-        Just
-          . OpenApi.Inline
-          $ mempty
-            { OpenApi._schemaType = Just OpenApi.OpenApiString
-            }
+    , OpenApi._paramSchema = Just (mkParamSchema param)
     }
 
 mkOpenApiScalarParam ::

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -4,6 +4,7 @@ module Fixtures
 
 import Fixtures.GetWithCookies as Export
 import Fixtures.GetWithHeaders as Export
+import Fixtures.GetWithPathParams as Export
 import Fixtures.GetWithQuery as Export
 import Fixtures.NoPermissions as Export
 import Fixtures.NullableRef as Export

--- a/test/Fixtures/GetWithPathParams.hs
+++ b/test/Fixtures/GetWithPathParams.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Fixtures.GetWithPathParams
+  ( GetWithPathParams (..)
+  , getWithPathParamsOpenApiRouter
+  ) where
+
+import Beeline.Routing ((/+), (/-), (/:))
+import Beeline.Routing qualified as R
+import Data.Int qualified as Int
+import Data.Text qualified as T
+import Shrubbery qualified as S
+
+import Fixtures.NoPermissions (NoPermissions (NoPermissions))
+import Orb qualified
+import TestDispatchM qualified as TDM
+
+getWithPathParamsOpenApiRouter :: Orb.OpenApiProvider r => r (S.Union '[GetWithPathParams])
+getWithPathParamsOpenApiRouter =
+  Orb.provideOpenApi "get-with-path-params"
+    . R.routeList
+    $ Orb.get
+      ( R.make GetWithPathParams
+          /- "test"
+          /+ R.Param (R.textParam "textPathParam") getWithPathParamsTextParam
+          /+ R.Param (R.int32Param "int32PathParam") getWithPathParamsInt32Param
+      )
+      /: R.emptyRoutes
+
+data GetWithPathParams = GetWithPathParams
+  { getWithPathParamsTextParam :: T.Text
+  , getWithPathParamsInt32Param :: Int.Int32
+  }
+
+instance Orb.HasHandler GetWithPathParams where
+  type HandlerResponses GetWithPathParams = TestResponses
+  type HandlerPermissionAction GetWithPathParams = NoPermissions
+  type HandlerMonad GetWithPathParams = TDM.TestDispatchM
+  routeHandler = handler
+
+type TestResponses =
+  [ Orb.Response200 Orb.SuccessMessage
+  , Orb.Response500 Orb.InternalServerError
+  ]
+
+handler :: Orb.Handler GetWithPathParams
+handler =
+  Orb.Handler
+    { Orb.handlerId = "getWithPathParams"
+    , Orb.requestBody = Orb.EmptyRequestBody
+    , Orb.requestQuery = Orb.EmptyRequestQuery
+    , Orb.requestHeaders = Orb.EmptyRequestHeaders
+    , Orb.handlerResponseBodies =
+        Orb.responseBodies
+          . Orb.addResponseSchema200 Orb.successMessageSchema
+          . Orb.addResponseSchema500 Orb.internalServerErrorSchema
+          $ Orb.noResponseBodies
+    , Orb.mkPermissionAction =
+        \_request -> NoPermissions
+    , Orb.handleRequest =
+        \_request () ->
+          Orb.return200 (Orb.SuccessMessage "getWithPathParams")
+    }

--- a/test/OpenApi.hs
+++ b/test/OpenApi.hs
@@ -26,6 +26,7 @@ testGroup =
     , test_getWithQuery
     , test_getWithHeaders
     , test_getWithCookies
+    , test_getWithPathParams
     , test_openApiSubset
     , test_nullableRefOpenApi
     , test_unionOpenApi
@@ -95,6 +96,13 @@ test_getWithCookies =
     "Generates the correct OpenAPI JSON for a get with header params"
     "test/examples/get-with-cookies.json"
     $ mkTestOpenApi Fixtures.getWithCookiesOpenApiRouter "get-with-cookies"
+
+test_getWithPathParams :: Tasty.TestTree
+test_getWithPathParams =
+  mkGoldenTest
+    "Generates the correct OpenAPI JSON for a get with path params"
+    "test/examples/get-with-path-params.json"
+    $ mkTestOpenApi Fixtures.getWithPathParamsOpenApiRouter "get-with-path-params"
 
 test_openApiSubset :: Tasty.TestTree
 test_openApiSubset =

--- a/test/examples/get-with-path-params.json
+++ b/test/examples/get-with-path-params.json
@@ -1,0 +1,83 @@
+{
+    "components": {
+        "schemas": {
+            "InternalServerError": {
+                "properties": {
+                    "internal_server_error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "internal_server_error"
+                ],
+                "title": "InternalServerError",
+                "type": "object"
+            },
+            "SuccessMessage": {
+                "properties": {
+                    "success": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "success"
+                ],
+                "title": "SuccessMessage",
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/test/{textPathParam}/{int32PathParam}": {
+            "get": {
+                "operationId": "getWithPathParams",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SuccessMessage"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "in": "path",
+                    "name": "textPathParam",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                {
+                    "in": "path",
+                    "name": "int32PathParam",
+                    "required": true,
+                    "schema": {
+                        "format": "int32",
+                        "type": "integer"
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Previously we were generating all path params as strings for some
reason, which meant that clients generated from our specs would have
text instead of (for example) int32. This fixes that.
