### PR TITLE
Adds support for generate bounds on OpenAPI items

### DIFF
--- a/orb.cabal
+++ b/orb.cabal
@@ -127,6 +127,7 @@ test-suite orb-test
       Fixtures.NullableRef
       Fixtures.NullableRefCollectComponents
       Fixtures.OpenApiSubset
+      Fixtures.SchemaBounds
       Fixtures.SchemaDescriptions
       Fixtures.SimpleGet
       Fixtures.SimplePost

--- a/orb.cabal
+++ b/orb.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           orb
-version:        0.7.0.0
+version:        0.7.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/orb#readme>
 homepage:       https://github.com/flipstone/orb#readme
 bug-reports:    https://github.com/flipstone/orb/issues
@@ -79,7 +79,7 @@ library
       aeson
     , aeson-pretty
     , base >=4.7 && <5
-    , beeline-params ==0.1.*
+    , beeline-params ==0.2.*
     , beeline-routing ==0.3.*
     , bytestring
     , case-insensitive
@@ -148,7 +148,7 @@ test-suite orb-test
       aeson
     , aeson-pretty
     , base >=4.7 && <5
-    , beeline-params ==0.1.*
+    , beeline-params ==0.2.*
     , beeline-routing
     , bytestring
     , case-insensitive

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                orb
-version:             0.7.0.0
+version:             0.7.1.0
 github:              "flipstone/orb"
 license:             MIT
 author:              "Flipstone Technology Partners, Inc"
@@ -51,7 +51,7 @@ dependencies:
   - base >= 4.7 && < 5
   - aeson
   - aeson-pretty
-  - beeline-params >= 0.1 && < 0.2
+  - beeline-params >= 0.2 && < 0.3
   - beeline-routing >= 0.3 && < 0.4
   - bytestring
   - case-insensitive

--- a/src/Orb/OpenApi.hs
+++ b/src/Orb/OpenApi.hs
@@ -1377,6 +1377,90 @@ instance FC.Fleece FleeceOpenApi where
       . InternalError
       $ "Fleece jsonString is not currently implemented for OpenApi"
 
+  interpretMinLength len schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        addMinLength schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaMinLength = Just len
+                  }
+            }
+      in
+        fmap addMinLength . mkErrOrSchemaInfo
+
+  interpretMaxLength len schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        addMaxLength schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaMaxLength = Just len
+                  }
+            }
+      in
+        fmap addMaxLength . mkErrOrSchemaInfo
+
+  interpretMinItems len schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        addMinItems schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaMinItems = Just len
+                  }
+            }
+      in
+        fmap addMinItems . mkErrOrSchemaInfo
+
+  interpretMaxItems len schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        addMaxItems schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaMaxItems = Just len
+                  }
+            }
+      in
+        fmap addMaxItems . mkErrOrSchemaInfo
+
+  interpretMinimum val schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        addMinimum schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaMinimum = Just (fromInteger val)
+                  }
+            }
+      in
+        fmap addMinimum . mkErrOrSchemaInfo
+
+  interpretMaximum val schema =
+    FleeceOpenApi $
+      let
+        FleeceOpenApi mkErrOrSchemaInfo = FC.schemaInterpreter schema
+        addMaximum schemaInfo =
+          schemaInfo
+            { openApiSchema =
+                (openApiSchema schemaInfo)
+                  { OpenApi._schemaMaximum = Just (fromInteger val)
+                  }
+            }
+      in
+        fmap addMaximum . mkErrOrSchemaInfo
+
   --
   -- Default implementations we override to get OpenAPI specific behavior.
   -- Unfortunately this requires that we duplicate the default implementations

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 161aeaedc699c4bb8e85bfa605d9cf606fb97713
+    commit: 98790eaf6e422bf8c7caab42a649329aa6bddf2f
     subdirs:
       - json-fleece-aeson
       - json-fleece-core

--- a/stack-ghc-9.10.yaml
+++ b/stack-ghc-9.10.yaml
@@ -3,7 +3,7 @@
 resolver: lts-24.12
 extra-deps:
   - github: flipstone/beeline
-    commit: ad51a5197ba71b44f27fd760c6c241ac67f0a52f
+    commit: 0b2536c63089ca6bd8f4872787261f4cabe0be61
     subdirs:
       - beeline-params
       - beeline-routing
@@ -11,7 +11,11 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 98790eaf6e422bf8c7caab42a649329aa6bddf2f
+    commit: d4ba35fbc084036558ee1242b0bec7ad1669720c
     subdirs:
       - json-fleece-aeson
       - json-fleece-core
+  - github: flipstone/bounded-text
+    commit: 3ef94eeda5402857423284d0c4e021a8c8032498
+  - template-haskell-lift-0.1.0.0
+  - template-haskell-quasiquoter-0.1.0.0

--- a/stack-ghc-9.10.yaml.lock
+++ b/stack-ghc-9.10.yaml.lock
@@ -59,27 +59,27 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
+      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
       size: 491
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
-    version: 0.11.0.0
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 snapshots:
 - completed:
     sha256: 0d0bb681dd5be9b930c8fc070d717aae757b9aed176ae6047d87624b46406816

--- a/stack-ghc-9.10.yaml.lock
+++ b/stack-ghc-9.10.yaml.lock
@@ -7,42 +7,42 @@ packages:
 - completed:
     name: beeline-params
     pantry-tree:
-      sha256: 45904abe4737db4c3a8600bb6a2a0900085f58165c03f8e5e1249cbdd04d2bef
-      size: 1069
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+      sha256: d0db931040ec4773c3af456cad1ef600ed35438b23d3a1c7d15c2ad57b194558
+      size: 1210
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.1.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.2.0.0
   original:
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-routing
     pantry-tree:
-      sha256: 447f2eaffee4cc4d8763c89d1f1c80e4b90e73c6556c644c9949d04508ff3cd2
+      sha256: ac9788a17532bdb3b7e77c7324e8f78f4f65ff12fe8828dfee16960aea2ba246
       size: 1119
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.3.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.3.0.2
   original:
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-http-client
     pantry-tree:
-      sha256: bf286adfffe7795c07a058a162f112d1fd48f42c4aa72c74e80ac9f8ddd2ed21
+      sha256: f15d423a64227d7bf1b2f8cc32f124eafb4e2af3b436350c551998d21178175e
       size: 725
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.9.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.9.0.2
   original:
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: shrubbery
     pantry-tree:
@@ -59,27 +59,52 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
-    size: 3084186
+    sha256: 231837e421135133ebee81cb678530eee050303ee40996f2ea459f49bf74c8b0
+    size: 3086219
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
+      sha256: 6932ac19e24bd947d3689b686d17a85066b38ddfbe94f7914d302f66f5646881
       size: 491
-    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
-    size: 3084186
+    sha256: 231837e421135133ebee81cb678530eee050303ee40996f2ea459f49bf74c8b0
+    size: 3086219
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
     version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
+- completed:
+    name: bounded-text
+    pantry-tree:
+      sha256: e98540b1877ae4709420472f83e8fd04b987eaeb914df72bb33b0bbe55debac2
+      size: 2162
+    sha256: 29c500737d8e481fe2e3325fe643a9cafc565ffd06b754bf14219f579d927f5d
+    size: 11885
+    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+    version: 0.1.2.0
+  original:
+    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+- completed:
+    hackage: template-haskell-lift-0.1.0.0@sha256:f6cd3ee45b0c68480c400bfca9f08f39e8e87a5eb823f206dbe06ab1923a4f1c,1136
+    pantry-tree:
+      sha256: 56ab994094c839bebb643ce5fc58dfae6269517ebe91f380e259adaf1def08bf
+      size: 243
+  original:
+    hackage: template-haskell-lift-0.1.0.0
+- completed:
+    hackage: template-haskell-quasiquoter-0.1.0.0@sha256:71027c432c0fb1a293d0f2b1d46dd5be42b9703b7c4b2233ea8076bfc6f84aae,1181
+    pantry-tree:
+      sha256: f9f5177a522cc273c001dd5bd749e4f7ed841910c6136711b9b9825bc0bc9c56
+      size: 257
+  original:
+    hackage: template-haskell-quasiquoter-0.1.0.0
 snapshots:
 - completed:
     sha256: 0d0bb681dd5be9b930c8fc070d717aae757b9aed176ae6047d87624b46406816

--- a/stack-ghc-9.6.yaml
+++ b/stack-ghc-9.6.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 161aeaedc699c4bb8e85bfa605d9cf606fb97713
+    commit: 98790eaf6e422bf8c7caab42a649329aa6bddf2f
     subdirs:
       - json-fleece-aeson
       - json-fleece-core

--- a/stack-ghc-9.6.yaml
+++ b/stack-ghc-9.6.yaml
@@ -3,7 +3,7 @@
 resolver: lts-22.44
 extra-deps:
   - github: flipstone/beeline
-    commit: ad51a5197ba71b44f27fd760c6c241ac67f0a52f
+    commit: 0b2536c63089ca6bd8f4872787261f4cabe0be61
     subdirs:
       - beeline-params
       - beeline-routing
@@ -11,7 +11,11 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 98790eaf6e422bf8c7caab42a649329aa6bddf2f
+    commit: d4ba35fbc084036558ee1242b0bec7ad1669720c
     subdirs:
       - json-fleece-aeson
       - json-fleece-core
+  - github: flipstone/bounded-text
+    commit: 3ef94eeda5402857423284d0c4e021a8c8032498
+  - template-haskell-lift-0.1.0.0
+  - template-haskell-quasiquoter-0.1.0.0

--- a/stack-ghc-9.6.yaml.lock
+++ b/stack-ghc-9.6.yaml.lock
@@ -59,27 +59,27 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
+      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
       size: 491
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
-    version: 0.11.0.0
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 snapshots:
 - completed:
     sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9

--- a/stack-ghc-9.6.yaml.lock
+++ b/stack-ghc-9.6.yaml.lock
@@ -7,42 +7,42 @@ packages:
 - completed:
     name: beeline-params
     pantry-tree:
-      sha256: 45904abe4737db4c3a8600bb6a2a0900085f58165c03f8e5e1249cbdd04d2bef
-      size: 1069
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+      sha256: d0db931040ec4773c3af456cad1ef600ed35438b23d3a1c7d15c2ad57b194558
+      size: 1210
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.1.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.2.0.0
   original:
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-routing
     pantry-tree:
-      sha256: 447f2eaffee4cc4d8763c89d1f1c80e4b90e73c6556c644c9949d04508ff3cd2
+      sha256: ac9788a17532bdb3b7e77c7324e8f78f4f65ff12fe8828dfee16960aea2ba246
       size: 1119
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.3.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.3.0.2
   original:
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-http-client
     pantry-tree:
-      sha256: bf286adfffe7795c07a058a162f112d1fd48f42c4aa72c74e80ac9f8ddd2ed21
+      sha256: f15d423a64227d7bf1b2f8cc32f124eafb4e2af3b436350c551998d21178175e
       size: 725
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.9.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.9.0.2
   original:
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: shrubbery
     pantry-tree:
@@ -59,27 +59,52 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
-    size: 3084186
+    sha256: 231837e421135133ebee81cb678530eee050303ee40996f2ea459f49bf74c8b0
+    size: 3086219
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
+      sha256: 6932ac19e24bd947d3689b686d17a85066b38ddfbe94f7914d302f66f5646881
       size: 491
-    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
-    size: 3084186
+    sha256: 231837e421135133ebee81cb678530eee050303ee40996f2ea459f49bf74c8b0
+    size: 3086219
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
     version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
+- completed:
+    name: bounded-text
+    pantry-tree:
+      sha256: e98540b1877ae4709420472f83e8fd04b987eaeb914df72bb33b0bbe55debac2
+      size: 2162
+    sha256: 29c500737d8e481fe2e3325fe643a9cafc565ffd06b754bf14219f579d927f5d
+    size: 11885
+    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+    version: 0.1.2.0
+  original:
+    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+- completed:
+    hackage: template-haskell-lift-0.1.0.0@sha256:f6cd3ee45b0c68480c400bfca9f08f39e8e87a5eb823f206dbe06ab1923a4f1c,1136
+    pantry-tree:
+      sha256: 56ab994094c839bebb643ce5fc58dfae6269517ebe91f380e259adaf1def08bf
+      size: 243
+  original:
+    hackage: template-haskell-lift-0.1.0.0
+- completed:
+    hackage: template-haskell-quasiquoter-0.1.0.0@sha256:71027c432c0fb1a293d0f2b1d46dd5be42b9703b7c4b2233ea8076bfc6f84aae,1181
+    pantry-tree:
+      sha256: f9f5177a522cc273c001dd5bd749e4f7ed841910c6136711b9b9825bc0bc9c56
+      size: 257
+  original:
+    hackage: template-haskell-quasiquoter-0.1.0.0
 snapshots:
 - completed:
     sha256: 238fa745b64f91184f9aa518fe04bdde6552533d169b0da5256670df83a0f1a9

--- a/stack-ghc-9.8.yaml
+++ b/stack-ghc-9.8.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 161aeaedc699c4bb8e85bfa605d9cf606fb97713
+    commit: 98790eaf6e422bf8c7caab42a649329aa6bddf2f
     subdirs:
       - json-fleece-aeson
       - json-fleece-core

--- a/stack-ghc-9.8.yaml
+++ b/stack-ghc-9.8.yaml
@@ -3,7 +3,7 @@
 resolver: lts-23.28
 extra-deps:
   - github: flipstone/beeline
-    commit: ad51a5197ba71b44f27fd760c6c241ac67f0a52f
+    commit: 0b2536c63089ca6bd8f4872787261f4cabe0be61
     subdirs:
       - beeline-params
       - beeline-routing
@@ -11,7 +11,11 @@ extra-deps:
   - github: flipstone/shrubbery
     commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
   - github: flipstone/json-fleece
-    commit: 98790eaf6e422bf8c7caab42a649329aa6bddf2f
+    commit: d4ba35fbc084036558ee1242b0bec7ad1669720c
     subdirs:
       - json-fleece-aeson
       - json-fleece-core
+  - github: flipstone/bounded-text
+    commit: 3ef94eeda5402857423284d0c4e021a8c8032498
+  - template-haskell-lift-0.1.0.0
+  - template-haskell-quasiquoter-0.1.0.0

--- a/stack-ghc-9.8.yaml.lock
+++ b/stack-ghc-9.8.yaml.lock
@@ -59,27 +59,27 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
+      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
       size: 491
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
-    version: 0.11.0.0
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 snapshots:
 - completed:
     sha256: 7e724f347d5969cb5e8dde9f9aae30996e3231c29d1dafd45f21f1700d4c4fcb

--- a/stack-ghc-9.8.yaml.lock
+++ b/stack-ghc-9.8.yaml.lock
@@ -7,42 +7,42 @@ packages:
 - completed:
     name: beeline-params
     pantry-tree:
-      sha256: 45904abe4737db4c3a8600bb6a2a0900085f58165c03f8e5e1249cbdd04d2bef
-      size: 1069
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+      sha256: d0db931040ec4773c3af456cad1ef600ed35438b23d3a1c7d15c2ad57b194558
+      size: 1210
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.1.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.2.0.0
   original:
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-routing
     pantry-tree:
-      sha256: 447f2eaffee4cc4d8763c89d1f1c80e4b90e73c6556c644c9949d04508ff3cd2
+      sha256: ac9788a17532bdb3b7e77c7324e8f78f4f65ff12fe8828dfee16960aea2ba246
       size: 1119
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.3.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.3.0.2
   original:
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-http-client
     pantry-tree:
-      sha256: bf286adfffe7795c07a058a162f112d1fd48f42c4aa72c74e80ac9f8ddd2ed21
+      sha256: f15d423a64227d7bf1b2f8cc32f124eafb4e2af3b436350c551998d21178175e
       size: 725
-    sha256: 24eb20b509eeb14ca9a64d9e9c00cf13b805c178b3a938304f82159cd9d4a6ff
-    size: 34812
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
-    version: 0.9.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.9.0.2
   original:
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/ad51a5197ba71b44f27fd760c6c241ac67f0a52f.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: shrubbery
     pantry-tree:
@@ -59,27 +59,52 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
-    size: 3084186
+    sha256: 231837e421135133ebee81cb678530eee050303ee40996f2ea459f49bf74c8b0
+    size: 3086219
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
+      sha256: 6932ac19e24bd947d3689b686d17a85066b38ddfbe94f7914d302f66f5646881
       size: 491
-    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
-    size: 3084186
+    sha256: 231837e421135133ebee81cb678530eee050303ee40996f2ea459f49bf74c8b0
+    size: 3086219
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
     version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/d4ba35fbc084036558ee1242b0bec7ad1669720c.tar.gz
+- completed:
+    name: bounded-text
+    pantry-tree:
+      sha256: e98540b1877ae4709420472f83e8fd04b987eaeb914df72bb33b0bbe55debac2
+      size: 2162
+    sha256: 29c500737d8e481fe2e3325fe643a9cafc565ffd06b754bf14219f579d927f5d
+    size: 11885
+    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+    version: 0.1.2.0
+  original:
+    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+- completed:
+    hackage: template-haskell-lift-0.1.0.0@sha256:f6cd3ee45b0c68480c400bfca9f08f39e8e87a5eb823f206dbe06ab1923a4f1c,1136
+    pantry-tree:
+      sha256: 56ab994094c839bebb643ce5fc58dfae6269517ebe91f380e259adaf1def08bf
+      size: 243
+  original:
+    hackage: template-haskell-lift-0.1.0.0
+- completed:
+    hackage: template-haskell-quasiquoter-0.1.0.0@sha256:71027c432c0fb1a293d0f2b1d46dd5be42b9703b7c4b2233ea8076bfc6f84aae,1181
+    pantry-tree:
+      sha256: f9f5177a522cc273c001dd5bd749e4f7ed841910c6136711b9b9825bc0bc9c56
+      size: 257
+  original:
+    hackage: template-haskell-quasiquoter-0.1.0.0
 snapshots:
 - completed:
     sha256: 7e724f347d5969cb5e8dde9f9aae30996e3231c29d1dafd45f21f1700d4c4fcb

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -59,27 +59,27 @@ packages:
     pantry-tree:
       sha256: c1204bd17604272fdcdff26ea9e7b932c3bd311acaad307835a37eb3038566f5
       size: 628
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
     version: 0.5.0.0
   original:
     subdir: json-fleece-aeson
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 - completed:
     name: json-fleece-core
     pantry-tree:
-      sha256: 2a4160e5337f7caff2591c32529e8b1b6366c1be335bb53ad64e59e8b986a14e
+      sha256: 6ab78e6f40434229a52673305b7e7da17ec4ef41ed86d0221e5ebf7a549653d2
       size: 491
-    sha256: 5567116b8b6465b52e0b9c2ff23583f854c28e32988a09c5d6d10b10fe2ea289
-    size: 3075860
+    sha256: dff5bb600583bd692b2cf6ef0009c83271bcae7a7ac077f0a9d21289b218d86b
+    size: 3084186
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
-    version: 0.11.0.0
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
+    version: 0.11.1.0
   original:
     subdir: json-fleece-core
-    url: https://github.com/flipstone/json-fleece/archive/161aeaedc699c4bb8e85bfa605d9cf606fb97713.tar.gz
+    url: https://github.com/flipstone/json-fleece/archive/98790eaf6e422bf8c7caab42a649329aa6bddf2f.tar.gz
 snapshots:
 - completed:
     sha256: 0d0bb681dd5be9b930c8fc070d717aae757b9aed176ae6047d87624b46406816

--- a/test/Fixtures.hs
+++ b/test/Fixtures.hs
@@ -10,6 +10,7 @@ import Fixtures.NoPermissions as Export
 import Fixtures.NullableRef as Export
 import Fixtures.NullableRefCollectComponents as Export
 import Fixtures.OpenApiSubset as Export
+import Fixtures.SchemaBounds as Export
 import Fixtures.SimpleGet as Export
 import Fixtures.SimplePost as Export
 import Fixtures.TaggedUnion as Export

--- a/test/Fixtures/SchemaBounds.hs
+++ b/test/Fixtures/SchemaBounds.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Fixtures.SchemaBounds
+  ( SchemaBounds (..)
+  , schemaBoundsOpenApiRouter
+  ) where
+
+import Beeline.Routing ((/-), (/:))
+import Beeline.Routing qualified as R
+import Data.Text qualified as T
+import Fleece.Core ((#+))
+import Fleece.Core qualified as FC
+import Shrubbery qualified as S
+
+import Fixtures.NoPermissions (NoPermissions (NoPermissions))
+import Orb qualified
+import TestDispatchM qualified as TDM
+
+schemaBoundsOpenApiRouter :: Orb.OpenApiProvider r => r (S.Union '[SchemaBounds])
+schemaBoundsOpenApiRouter =
+  Orb.provideOpenApi "schema-bounds"
+    . R.routeList
+    $ Orb.get (R.make SchemaBounds /- "test" /- "schema_bounds")
+      /: R.emptyRoutes
+
+data SchemaBounds = SchemaBounds
+
+instance Orb.HasHandler SchemaBounds where
+  type HandlerResponses SchemaBounds = Responses
+  type HandlerPermissionAction SchemaBounds = NoPermissions
+  type HandlerMonad SchemaBounds = TDM.TestDispatchM
+  routeHandler = handler
+
+type Responses =
+  [ Orb.Response200 SchemaBoundsResponse
+  , Orb.Response500 Orb.InternalServerError
+  ]
+
+data SchemaBoundsResponse = SchemaBoundsResponse
+  { boundedTextField :: T.Text
+  , boundedListField :: [T.Text]
+  , boundedNumberField :: Int
+  }
+
+schemaBoundsResponseSchema :: FC.Fleece t => FC.Schema t SchemaBoundsResponse
+schemaBoundsResponseSchema =
+  FC.object $
+    FC.constructor SchemaBoundsResponse
+      #+ FC.required "bounded_text" boundedTextField (FC.maxLength 100 $ FC.minLength 1 FC.text)
+      #+ FC.required "bounded_list" boundedListField (FC.maxItems 50 $ FC.minItems 1 (FC.list FC.text))
+      #+ FC.required "bounded_number" boundedNumberField (FC.maximum 1000 $ FC.minimum 0 FC.int)
+
+handler :: Orb.Handler SchemaBounds
+handler =
+  Orb.Handler
+    { Orb.handlerId = "schemaBounds"
+    , Orb.requestBody = Orb.EmptyRequestBody
+    , Orb.requestQuery = Orb.EmptyRequestQuery
+    , Orb.requestHeaders = Orb.EmptyRequestHeaders
+    , Orb.handlerResponseBodies =
+        Orb.responseBodies
+          . Orb.addResponseSchema200 schemaBoundsResponseSchema
+          . Orb.addResponseSchema500 Orb.internalServerErrorSchema
+          $ Orb.noResponseBodies
+    , Orb.mkPermissionAction =
+        \_request -> NoPermissions
+    , Orb.handleRequest =
+        \_request () ->
+          Orb.return200
+            SchemaBoundsResponse
+              { boundedTextField = "hello"
+              , boundedListField = ["item"]
+              , boundedNumberField = 42
+              }
+    }

--- a/test/OpenApi.hs
+++ b/test/OpenApi.hs
@@ -32,6 +32,7 @@ testGroup =
     , test_unionOpenApi
     , test_taggedUnionOpenApi
     , test_nullableRefCollectComponentsOpenApi
+    , test_schemaBoundsOpenApi
     ]
 
 test_openApiUnknownLabel :: Tasty.TestTree
@@ -138,6 +139,13 @@ test_nullableRefCollectComponentsOpenApi =
     "Generates the correct OpenAPI JSON for a nullable schema with an inner object schema"
     "test/examples/nullable-ref-collect-components.json"
     $ mkTestOpenApi Fixtures.nullableRefCollectComponentsOpenApiRouter "nullable-ref-collect-components"
+
+test_schemaBoundsOpenApi :: Tasty.TestTree
+test_schemaBoundsOpenApi =
+  mkGoldenTest
+    "Generates the correct OpenAPI JSON for schemas with bounds"
+    "test/examples/schema-bounds.json"
+    $ mkTestOpenApi Fixtures.schemaBoundsOpenApiRouter "schema-bounds"
 
 mkTestOpenApi :: Orb.OpenApiRouter a -> String -> Either [Orb.OpenApiError] OpenApi.OpenApi
 mkTestOpenApi =

--- a/test/examples/schema-bounds.json
+++ b/test/examples/schema-bounds.json
@@ -1,0 +1,81 @@
+{
+    "components": {
+        "schemas": {
+            "InternalServerError": {
+                "properties": {
+                    "internal_server_error": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "internal_server_error"
+                ],
+                "title": "InternalServerError",
+                "type": "object"
+            },
+            "SchemaBoundsResponse": {
+                "properties": {
+                    "bounded_list": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "maxItems": 50,
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "bounded_number": {
+                        "maximum": 1000,
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "bounded_text": {
+                        "maxLength": 100,
+                        "minLength": 1,
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "bounded_text",
+                    "bounded_list",
+                    "bounded_number"
+                ],
+                "title": "SchemaBoundsResponse",
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "/test/schema_bounds": {
+            "get": {
+                "operationId": "schemaBounds",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SchemaBoundsResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/InternalServerError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This depends on the new `json-fleece` support for bounds annotations
on schemas. It will be get merged after those changes are merged to
fleece.
